### PR TITLE
Fix name of referenced cookie and a typo

### DIFF
--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.9_Fingerprint_Web_Application_OTG-INFO-009.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.9_Fingerprint_Web_Application_OTG-INFO-009.md
@@ -27,7 +27,7 @@ Connection: keep-alive
 Host: blog.owasp.org
 ```
 
-The cookie *wp-settings-time-1* has automatically been set, which gives information about the framework being used. List of common cookies names is presented in Common Application Identifiers section. However, it is possible to change the name of the cookie.
+The cookie *wp-settings-time-1* has automatically been set, which gives information about the framework being used. List of common cookies names is presented in [Common Application Identifiers](#common-application-identifiers) section. However, it is possible to change the name of the cookie.
 
 ### HTML Source Code
 

--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.9_Fingerprint_Web_Application_OTG-INFO-009.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.9_Fingerprint_Web_Application_OTG-INFO-009.md
@@ -27,7 +27,7 @@ Connection: keep-alive
 Host: blog.owasp.org
 ```
 
-The cookie *CAKEPHP* has automatically been set, which gives information about the framework being used. List of common cookies names is presented in Cpmmon Application Identifiers section. However, it is possible to change the name of the cookie.
+The cookie *wp-settings-time-1* has automatically been set, which gives information about the framework being used. List of common cookies names is presented in Common Application Identifiers section. However, it is possible to change the name of the cookie.
 
 ### HTML Source Code
 


### PR DESCRIPTION
- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Fix referenced cookie name in text (example output does not contain _CAKEPHP_ cookie anymore)
- Fix a typo on the same line