### PR TITLE
Update CI/Lint config post repo rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstg",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/OWASP/wstg/issues) [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-brightgreen.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Flagship_Projects)",
   "main": "index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "OWASP Web Security Testing Guide",
+  "name": "wstg",
   "version": "1.0.0",
   "description": "[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/OWASP/wstg/issues) [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-brightgreen.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Flagship_Projects)",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "owasp-testing-guide-v5",
+  "name": "OWASP Web Security Testing Guide",
   "version": "1.0.0",
-  "description": "[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/OWASP/OWASP-Testing-Guide-v5/issues) [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-brightgreen.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Flagship_Projects)",
+  "description": "[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/OWASP/wstg/issues) [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-brightgreen.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Flagship_Projects)",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
@@ -12,12 +12,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/OWASP/OWASP-Testing-Guide-v5.git"
+    "url": "git+https://github.com/OWASP/wstg.git"
   },
   "author": "OWASP",
   "license": "CC-BY-SA-4.0",
   "bugs": {
-    "url": "https://github.com/OWASP/OWASP-Testing-Guide-v5/issues"
+    "url": "https://github.com/OWASP/wstg/issues"
   },
-  "homepage": "https://github.com/OWASP/OWASP-Testing-Guide-v5#readme"
+  "homepage": "https://github.com/OWASP/wstg#readme"
 }


### PR DESCRIPTION
- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

Change name, URLs, refs to use wstg instead of the old verbose URL.
Per: https://groups.google.com/a/owasp.org/forum/#!topic/leaders/LM7eYK3ZzcA
Follow-up to: https://github.com/OWASP/wstg/pull/222

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>