### PR TITLE
Add a section on timing attacks to the username enumeration guide.

### DIFF
--- a/document/4_Web_Application_Security_Testing/4.4_Identity_Management_Testing/4.4.4_Testing_for_Account_Enumeration_and_Guessable_User_Account_OTG-IDENT-004.md
+++ b/document/4_Web_Application_Security_Testing/4.4_Identity_Management_Testing/4.4.4_Testing_for_Account_Enumeration_and_Guessable_User_Account_OTG-IDENT-004.md
@@ -106,8 +106,8 @@ Testers can receive useful information on Title of web page, where they can obta
 
 For instance, if a user cannot authenticate to an application and receives a web page whose title is similar to:
 
-`Invalid user`
-`Invalid authentication`
+- `Invalid user`
+- `Invalid authentication`
 
 #### Analyzing a Message Received from a Recovery Facility
 
@@ -121,6 +121,10 @@ Invalid username: e-mail address is not valid or the specified user was not foun
 #### Friendly 404 Error Message
 
 When we request a user within the directory that does not exist, we don't always receive 404 error code. Instead, we may receive “200 ok” with an image, in this case we can assume that when we receive the specific image the user does not exist. This logic can be applied to other web server response; the trick is a good analysis of web server and web application messages.
+
+#### Analyzing Response Times
+
+As well as looking at the content of the responses, the time that the response take should also be considered. Particularly where the request causes an interaction with an external service (such as sending a forgotten password email), this can add several hundred milliseconds to the response, which can be used to determine whether the requested user is valid.
 
 ### Guessing Users
 


### PR DESCRIPTION
Added a small section about using response times to enumerate users to 4.4.4 - it works best on forgotten password functionality, but can sometimes work on other things.

Also fixed a couple of code blocks displaying on the same line (as markdown ignores single newlines).