### PR TITLE
Revise Link Check Action

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
     - master
+    paths:
+    - '**.md'
 
 jobs:
   link-check:
@@ -20,8 +22,20 @@ jobs:
         node-version: 12.x
     - name: Install dependencies
       run: npm install -g markdown-link-check
+    - name: Changed Files Exporter
+      id: files
+      uses: futuratrepadeira/changed-files@v3.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run link check
-      run: npm run-script link-check
+      env:
+        FILES: '${{ steps.files.outputs.files_updated }} ${{ steps.files.outputs.files_created }}'
+      run: |
+        echo "The Following files were changed or created:"
+        echo $FILES
+        touch log err
+        for FILE in $FILES; do echo $FILE | grep -q .*\.md\$ && markdown-link-check -c markdown-link-check-config.json $FILE 1>> log 2>> err; done
+        if grep -q  \"ERROR:\" err ; then exit 1 ; else echo -e \"No broken links found.\"; fi
     - name: Show broken links
       id: brokenlinks
       if: failure()

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "markdownlint-cli": "^0.19.0"
   },
+  "scripts": {
+    "test": "markdownlint .  --ignore node_modules"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OWASP/wstg.git"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
   "devDependencies": {
     "markdownlint-cli": "^0.19.0"
   },
-  "scripts": {
-    "test": "markdownlint .  --ignore node_modules",
-    "link-check" : "find  document -name \\*.md -exec markdown-link-check -c markdown-link-check-config.json 1> log 2> err {} \\; && if [ -e err ] && grep -q  \"ERROR:\" err ; then exit 113  ; else echo -e \"No broken links found.\"; fi"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OWASP/wstg.git"


### PR DESCRIPTION
- package.json > Remove 'link-check' script.
- md-link-check.yml > Only run when *.md files are included. Add 'Changed Files Exporter' step. Change 'Run link check' step to run CLI actions in-line.

Relevant test usage can be seen here in commits from "Test 37" onward: https://github.com/kingthorin/testwstg/pull/1
(Note the test repo will be deleted after this PR is approved/merged.)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>