### PR TITLE
Link Checker: remove push inclusion

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,7 +1,6 @@
 name: Markdown Link Check
 
 on:
-  push:
   pull_request:
     branches:
     - master


### PR DESCRIPTION
The link check doesn't need to run on pushes, and can't determine the changed/created files on push.

This resolves the action failure on merge.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>