### PR TITLE
Various small grammar fixes and typos

### DIFF
--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.2_Fingerprint_Web_Server_WSTG-INFO-002.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.2_Fingerprint_Web_Server_WSTG-INFO-002.md
@@ -162,7 +162,7 @@ Server: lighttpd/1.4.54
 
 As default error pages offer many differentiating factors between types of web servers, their examination can be an effective method for fingerprinting even when server header fields are obscured.
 
-### Using Automated Scan Tools
+### Using Automated Scanning Tools
 
 As stated earlier, web server fingerprinting is often included as a functionality of automated scanning tools. These tools are able to make requests similar to those demonstrated above, as well as send other more server-specific probes. Automated tools can compare responses from web servers much faster than manual testing, and utilize large databases of known responses to attempt server identification. For these reasons, automated tools are more likely to produce accurate results.
 

--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.6_Identify_Application_Entry_Points_WSTG-INFO-006.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.6_Identify_Application_Entry_Points_WSTG-INFO-006.md
@@ -47,7 +47,7 @@ The following are two examples on how to check for application entry points.
 This example shows a GET request that would purchase an item from an online shopping application.
 
 ```html
-GET [https://x.x.x.x/shoppingApp/buyme.asp?CUSTOMERID=100&ITEM=z101a&PRICE=62.50&IP=x.x.x.x]
+GET /shoppingApp/buyme.asp?CUSTOMERID=100&ITEM=z101a&PRICE=62.50&IP=x.x.x.x HTTP/1.1
 Host: x.x.x.x
 Cookie: SESSIONID=Z29vZCBqb2IgcGFkYXdhIG15IHVzZXJuYW1lIGlzIGZvbyBhbmQgcGFzc3dvcmQgaXMgYmFy
 ```
@@ -59,17 +59,15 @@ Cookie: SESSIONID=Z29vZCBqb2IgcGFkYXdhIG15IHVzZXJuYW1lIGlzIGZvbyBhbmQgcGFzc3dvc
 This example shows a POST request that would log you into an application.
 
 ```html
-POST [https://x.x.x.x/KevinNotSoGoodApp/authenticate.asp?service=login]
+POST /KevinNotSoGoodApp/authenticate.asp?service=login HTTP/1.1
 Host: x.x.x.x
 Cookie: SESSIONID=dGhpcyBpcyBhIGJhZCBhcHAgdGhhdCBzZXRzIHByZWRpY3RhYmxlIGNvb2tpZXMgYW5kIG1pbmUgaXMgMTIzNA==
 CustomCookie=00my00trusted00ip00is00x.x.x.x00
+
+user=admin&pass=pass123&debug=true&fromtrustIP=true
 ```
 
-Body of the POST message:
-
-`user=admin&pass=pass123&debug=true&fromtrustIP=true`
-
-> In this example the tester would note all the parameters as they have before but notice that the parameters are passed in the body of the message and not in the URL. Additionally, note that there is a custom cookie that is being used.
+> In this example the tester would note all the parameters as they have before, however the majority of parameters are passed in the body of the request and not in the URL. Additionally, note that there is a custom HTTP header (`CustomCookie`) being used.
 
 ### Gray-Box Testing
 

--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.6_Identify_Application_Entry_Points_WSTG-INFO-006.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.6_Identify_Application_Entry_Points_WSTG-INFO-006.md
@@ -67,7 +67,7 @@ CustomCookie=00my00trusted00ip00is00x.x.x.x00
 user=admin&pass=pass123&debug=true&fromtrustIP=true
 ```
 
-> In this example the tester would note all the parameters as they have before, however the majority of parameters are passed in the body of the request and not in the URL. Additionally, note that there is a custom HTTP header (`CustomCookie`) being used.
+> In this example the tester would note all the parameters as they have before, however the majority of the parameters are passed in the body of the request and not in the URL. Additionally, note that there is a custom HTTP header (`CustomCookie`) being used.
 
 ### Gray-Box Testing
 

--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.8_Fingerprint_Web_Application_Framework_WSTG-INFO-008.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.8_Fingerprint_Web_Application_Framework_WSTG-INFO-008.md
@@ -230,7 +230,9 @@ Best Guess: 7.14
 
 Website: [https://www.wappalyzer.com/](https://www.wappalyzer.com/)
 
-Wapplyzer is a Firefox Chrome plug-in. It works only on regular expression matching and doesn't need anything other than the page to be loaded on browser. It works completely at the browser level and gives results in the form of icons. Although sometimes it has false positives, this is very handy to have notion of what technologies were used to construct a target website immediately after browsing a page.
+Wapplyzer is a Firefox Chrome extension. It works only on regular expression matching and doesn't need anything other than the page to be loaded on browser. It works completely at the browser level and gives results in the form of icons. Although sometimes it has false positives, this is very handy to have notion of what technologies were used to construct a target website immediately after browsing a page.
+
+Note that by default, Wappalyzer will send anonymised data about the technology running on visited websites back to the developers, which is then sold to third parties. Make sure you disable this data collection in the add-on options.
 
 Sample output of a plug-in is presented on a screenshot below.
 

--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.8_Fingerprint_Web_Application_Framework_WSTG-INFO-008.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.8_Fingerprint_Web_Application_Framework_WSTG-INFO-008.md
@@ -6,7 +6,7 @@ Web framework[*] fingerprinting is an important subtask of the information gathe
 
 Several different vendors and versions of web frameworks are widely used. Information about it significantly helps in the testing process, and can also help in changing the course of the test. Such information can be derived by careful analysis of certain common locations. Most of the web frameworks have several markers in those locations which help an attacker to spot them. This is basically what all automatic tools do, they look for a marker from a predefined location and then compare it to the database of known signatures. For better accuracy several markers are usually used.
 
-[*] Please note that this article makes no differentiation between Web Application Frameworks (WAF) and Content Management Systems (CMS). This has been done to make it convenient to fingerprint both of them in one chapter. Furthermore, both categories are referenced as web frameworks.
+[*] Please note that this article makes no differentiation between Web Application Frameworks and Content Management Systems (CMS). This has been done to make it convenient to fingerprint both of them in one chapter. Furthermore, both categories are referenced as web frameworks.
 
 ## Test Objectives
 

--- a/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.9_Fingerprint_Web_Application_WSTG-INFO-009.md
+++ b/document/4_Web_Application_Security_Testing/4.2_Information_Gathering/4.2.9_Fingerprint_Web_Application_WSTG-INFO-009.md
@@ -165,7 +165,9 @@ Best Guess: 7.14
 
 Website: [https://www.wappalyzer.com/](https://www.wappalyzer.com/)
 
-Wapplyzer is a Firefox Chrome plug-in. It works only on regular expression matching and doesn't need anything other than the page to be loaded on browser. It works completely at the browser level and gives results in the form of icons. Although sometimes it has false positives, this is very handy to have notion of what technologies were used to construct a target website immediately after browsing a page.
+Wapplyzer is a Firefox Chrome extension. It works only on regular expression matching and doesn't need anything other than the page to be loaded on browser. It works completely at the browser level and gives results in the form of icons. Although sometimes it has false positives, this is very handy to have notion of what technologies were used to construct a target website immediately after browsing a page.
+
+Note that by default, Wappalyzer will send anonymised data about the technology running on visited websites back to the developers, which is then sold to third parties. Make sure you disable this data collection in the add-on options.
 
 Sample output of a plug-in is presented on a screenshot below.
 


### PR DESCRIPTION
Small fixes for a few things I noticed going through the information gathering section. Apologies for the slightly disjointed PR.

- Fix up the grammar in a few places.
- Fix the example HTTP requests so that they're valid.
- Add a warning that Wappalyzer sends anonymised data to the developers which is sold.