### PR TITLE
Fix link checker PR commenting issue in Github actions

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -49,7 +49,8 @@ jobs:
         echo ::set-output name=links::**Following links are broken:** %0A$links
     - name: Send comment to PR with broken links
       if: failure() && github.event_name == 'pull_request'
-      uses: thollander/actions-comment-pull-request@1.0.0
+      uses: mshick/add-pr-comment@v1
       with:
         message: ${{ steps.brokenlinks.outputs.links }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        allow-repeats: true


### PR DESCRIPTION

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Fix lick checker Github action task to put the broken links as a comment on PR.