### PR TITLE
4.9.5 Remove misleading examples

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage.md
@@ -56,28 +56,6 @@ Some Meta tags do not provide active attack vectors but instead allow an attacke
 <META name="Author" content="Andrew Muller">
 ```
 
-Some Meta tags alter HTTP response headers, such as http-equiv that sets an HTTP response header based on the the content attribute of a meta element, such as:
-
-```html
-<META http-equiv="Expires" content="Fri, 21 Dec 2012 12:34:56 GMT">
-```
-
-which will result in the HTTP header:
-
-`Expires: Fri, 21 Dec 2012 12:34:56 GMT`
-
-and
-
-```html
-<META http-equiv="Cache-Control" content="no-cache">
-```
-
-will result in
-
-`Cache-Control: no-cache`
-
-Test to see if this can be used to conduct injection attacks (e.g. CRLF attack). It can also help determine the level of data leakage via the browser cache.
-
 A common (but not WCAG compliant) Meta tag is the refresh.
 
 ```html


### PR DESCRIPTION
Fixes OWASP/wstg#365

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- 4.9.5 Remove misleading examples

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
