### PR TITLE
Chore Identifiers Cleanup

### DIFF
--- a/Testing_for_Horizontal_Bypassing_Authorization_Schema_WSTG-AUTHZ-002.md
+++ b/Testing_for_Horizontal_Bypassing_Authorization_Schema_WSTG-AUTHZ-002.md
@@ -1,4 +1,8 @@
-# Testing for Horizontal Bypassing Authorization Schema (WSTG-AUTHZ-002)
+# Testing for Horizontal Bypassing Authorization Schema
+
+|ID           |
+|-------------|
+|WSTG-ATHZ-002|
 
 ## Summary
 

--- a/Testing_for_Vertical_Bypassing_Authorization_Schema_WSTG-AUTHZ-00X.md
+++ b/Testing_for_Vertical_Bypassing_Authorization_Schema_WSTG-AUTHZ-00X.md
@@ -1,4 +1,8 @@
-# Testing for Vertical Bypassing Authorization Schema (WSTG-AUTHZ-00X)
+# Testing for Vertical Bypassing Authorization Schema
+
+|ID           |
+|-------------|
+|WSTG-ATHZ-00X|
 
 ## Summary
 

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -86,8 +86,8 @@ The following is the list of controls to test during the assessment:
 | 4.8.15   | WSTG-INPV-15 | Testing for incubated vulnerabilities |
 | 4.8.16   | WSTG-INPV-16 | Testing for HTTP Splitting/Smuggling |
 | **4.9**  | **WSTG-ERR**    | **Error Handling** |
-| 4.9.1    | WSTG-ERR-001    | Analysis of Error Codes |
-| 4.9.2    | WSTG-ERR-002    | Analysis of Stack Traces |
+| 4.9.1    | WSTG-ERRH-01    | Analysis of Error Codes |
+| 4.9.2    | WSTG-ERRH-02    | Analysis of Stack Traces |
 | **4.10** | **WSTG-CRYPST** | **Cryptography** |
 | 4.10.1   | WSTG-CRYPST-001 | Testing for Weak SSL/TSL Ciphers, Insufficient Transport Layer Protection  |
 | 4.10.2   | WSTG-CRYPST-002 | Testing for Padding Oracle |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -49,14 +49,14 @@ The following is the list of controls to test during the assessment:
 | 4.6.3    | WSTG-ATHZ-03 | Testing for Privilege Escalation |
 | 4.6.4    | WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
 | **4.7**  | **WSTG-SESS**  | **Session Management Testing** |
-| 4.7.1    | WSTG-SESS-001  | Testing for Bypassing Session Management Schema |
-| 4.7.2    | WSTG-SESS-002  | Testing for Cookies attributes |
-| 4.7.3    | WSTG-SESS-003  | Testing for Session Fixation |
-| 4.7.4    | WSTG-SESS-004  | Testing for Exposed Session Variables |
-| 4.7.5    | WSTG-SESS-005  | Testing for Cross Site Request Forgery |
-| 4.7.6    | WSTG-SESS-006  | Testing for logout functionality |
-| 4.7.7    | WSTG-SESS-007  | Test Session Timeout |
-| 4.7.8    | WSTG-SESS-008  | Testing for Session puzzling |
+| 4.7.1    | WSTG-SESS-01  | Testing for Bypassing Session Management Schema |
+| 4.7.2    | WSTG-SESS-02  | Testing for Cookies attributes |
+| 4.7.3    | WSTG-SESS-03  | Testing for Session Fixation |
+| 4.7.4    | WSTG-SESS-04  | Testing for Exposed Session Variables |
+| 4.7.5    | WSTG-SESS-05  | Testing for Cross Site Request Forgery |
+| 4.7.6    | WSTG-SESS-06  | Testing for logout functionality |
+| 4.7.7    | WSTG-SESS-07  | Test Session Timeout |
+| 4.7.8    | WSTG-SESS-08  | Testing for Session puzzling |
 | **4.8**  | **WSTG-INPVAL** | **Data Validation Testing** |
 | 4.8.1    | WSTG-INPVAL-001 | Testing for Reflected Cross Site Scripting |
 | 4.8.2    | WSTG-INPVAL-002 | Testing for Stored Cross Site Scripting |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -64,7 +64,7 @@ The following is the list of controls to test during the assessment:
 | 4.7.4 | WSTG-INPV-04 | Testing for HTTP Parameter pollution |
 | 4.7.5 | WSTG-INPV-05 | Testing for SQL Injection |
 | 4.7.5.1 | | Oracle Testing |
-| 4.7.5.2 | | MySQL Testing   |
+| 4.7.5.2 | | MySQL Testing |
 | 4.7.5.3 | | SQL Server Testing |
 | 4.7.5.4 | | Testing PostgreSQL |
 | 4.7.5.5 | | MS Access Testing |
@@ -89,9 +89,9 @@ The following is the list of controls to test during the assessment:
 | 4.7.16 | WSTG-INPV-16 | Testing for HTTP Incoming Requests |
 | 4.7.17 | WSTG-INPV-17 | Testing for Host Header Injection |
 | 4.7.18 | WSTG-INPV-18 | Testing for Server Side Template Injection |
-| **4.8** | **WSTG-ERRH**  |**Error Handling** |
-| 4.8.1 | WSTG-ERRH-01  | Analysis of Error Codes |
-| 4.8.2 | WSTG-ERRH-02  | Analysis of Stack Traces |
+| **4.8** | **WSTG-ERRH** |**Error Handling** |
+| 4.8.1 | WSTG-ERRH-01 | Analysis of Error Codes |
+| 4.8.2 | WSTG-ERRH-02 | Analysis of Stack Traces |
 | **4.9** | **WSTG-CRYP** | **Cryptography** |
 | 4.9.1 | WSTG-CRYP-01 | Testing for Weak Cryptography |
 | 4.9.2 | WSTG-CRYP-02 | Testing for Padding Oracle |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -16,14 +16,14 @@ The following is the list of controls to test during the assessment:
 | 4.2.9    | WSTG-INFO-09 | Fingerprint Web Application |
 | 4.2.10   | WSTG-INFO-10 | Map Application Architecture  |
 | **4.3**    | **WSTG-CONFIG** | **Configuration and Deploy Management Testing** |
-| 4.3.1    | WSTG-CONFIG-001 | Test Network/Infrastructure Configuration |
-| 4.3.2    | WSTG-CONFIG-002 | Test Application Platform Configuration |
-| 4.3.3    | WSTG-CONFIG-003 | Test File Extensions Handling for Sensitive Information |
-| 4.3.4    | WSTG-CONFIG-004 | Backup and Unreferenced Files for Sensitive Information |
-| 4.3.5    | WSTG-CONFIG-005 | Enumerate Infrastructure and Application Admin Interfaces  |
-| 4.3.6    | WSTG-CONFIG-006 | Test HTTP Methods |
-| 4.3.7    | WSTG-CONFIG-007 | Test HTTP Strict Transport Security |
-| 4.3.8    | WSTG-CONFIG-008 | Test RIA cross domain policy |
+| 4.3.1    | WSTG-CONF-01 | Test Network/Infrastructure Configuration |
+| 4.3.2    | WSTG-CONF-02 | Test Application Platform Configuration |
+| 4.3.3    | WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
+| 4.3.4    | WSTG-CONF-04 | Backup and Unreferenced Files for Sensitive Information |
+| 4.3.5    | WSTG-CONF-05 | Enumerate Infrastructure and Application Admin Interfaces  |
+| 4.3.6    | WSTG-CONF-06 | Test HTTP Methods |
+| 4.3.7    | WSTG-CONF-07 | Test HTTP Strict Transport Security |
+| 4.3.8    | WSTG-CONF-08 | Test RIA cross domain policy |
 | **4.4**  | **WSTG-IDENT**  | **Identity Management Testing** |
 | 4.4.1    | WSTG-IDENT-001  | Test Role Definitions |
 | 4.4.2    | WSTG-IDENT-002  | Test User Registration Process |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -58,33 +58,33 @@ The following is the list of controls to test during the assessment:
 | 4.7.7    | WSTG-SESS-07  | Test Session Timeout |
 | 4.7.8    | WSTG-SESS-08  | Testing for Session puzzling |
 | **4.8**  | **WSTG-INPVAL** | **Data Validation Testing** |
-| 4.8.1    | WSTG-INPVAL-001 | Testing for Reflected Cross Site Scripting |
-| 4.8.2    | WSTG-INPVAL-002 | Testing for Stored Cross Site Scripting |
-| 4.8.3    | WSTG-INPVAL-003 | Testing for HTTP Verb Tampering |
-| 4.8.4    | WSTG-INPVAL-004 | Testing for HTTP Parameter pollution |
-| 4.8.5    | WSTG-INPVAL-005 | Testing for SQL Injection |
+| 4.8.1    | WSTG-INPV-01 | Testing for Reflected Cross Site Scripting |
+| 4.8.2    | WSTG-INPV-02 | Testing for Stored Cross Site Scripting |
+| 4.8.3    | WSTG-INPV-03 | Testing for HTTP Verb Tampering |
+| 4.8.4    | WSTG-INPV-04 | Testing for HTTP Parameter pollution |
+| 4.8.5    | WSTG-INPV-05 | Testing for SQL Injection |
 | 4.8.5.1  |                | Oracle Testing |
 | 4.8.5.2  |                | MySQL Testing |
 | 4.8.5.3  |                | SQL Server Testing |
 | 4.8.5.4  |                | Testing PostgreSQL |
 | 4.8.5.5  |                | MS Access Testing |
 | 4.8.5.6  |                | Testing for NoSQL injection |
-| 4.8.6    | WSTG-INPVAL-006 | Testing for LDAP Injection |
-| 4.8.7    | WSTG-INPVAL-007 | Testing for ORM Injection |
-| 4.8.8    | WSTG-INPVAL-008 | Testing for XML Injection |
-| 4.8.9    | WSTG-INPVAL-009 | Testing for SSI Injection |
-| 4.8.10   | WSTG-INPVAL-010 | Testing for XPath Injection |
-| 4.8.11   | WSTG-INPVAL-011 | IMAP/SMTP Injection |
-| 4.8.12   | WSTG-INPVAL-012 | Testing for Code Injection |
+| 4.8.6    | WSTG-INPV-06 | Testing for LDAP Injection |
+| 4.8.7    | WSTG-INPV-07 | Testing for ORM Injection |
+| 4.8.8    | WSTG-INPV-08 | Testing for XML Injection |
+| 4.8.9    | WSTG-INPV-09 | Testing for SSI Injection |
+| 4.8.10   | WSTG-INPV-10 | Testing for XPath Injection |
+| 4.8.11   | WSTG-INPV-11 | IMAP/SMTP Injection |
+| 4.8.12   | WSTG-INPV-12 | Testing for Code Injection |
 | 4.8.12.1 |                | Testing for Local File Inclusion |
 | 4.8.12.2 |                | Testing for Remote File Inclusion |
-| 4.8.13   | WSTG-INPVAL-013 | Testing for Command Injection |
-| 4.8.14   | WSTG-INPVAL-014 | Testing for Buffer overflow |
+| 4.8.13   | WSTG-INPV-13 | Testing for Command Injection |
+| 4.8.14   | WSTG-INPV-14 | Testing for Buffer overflow |
 | 4.8.14.1 |                | Testing for Heap overflow |
 | 4.8.14.2 |                | Testing for Stack overflow |
 | 4.8.14.3 |                | Testing for Format string |
-| 4.8.15   | WSTG-INPVAL-015 | Testing for incubated vulnerabilities |
-| 4.8.16   | WSTG-INPVAL-016 | Testing for HTTP Splitting/Smuggling |
+| 4.8.15   | WSTG-INPV-15 | Testing for incubated vulnerabilities |
+| 4.8.16   | WSTG-INPV-16 | Testing for HTTP Splitting/Smuggling |
 | **4.9**  | **WSTG-ERR**    | **Error Handling** |
 | 4.9.1    | WSTG-ERR-001    | Analysis of Error Codes |
 | 4.9.2    | WSTG-ERR-002    | Analysis of Stack Traces |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -5,16 +5,16 @@ The following is the list of controls to test during the assessment:
 | Ref. No. | Category     | Test Name                  |
 |----------|--------------|----------------------------|
 | **4.2**  | **WSTG-INFO** | **Information Gathering**  |
-| 4.2.1    | WSTG-INFO-001 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
-| 4.2.2    | WSTG-INFO-002 | Fingerprint Web Server |
-| 4.2.3    | WSTG-INFO-003 | Review Webserver Metafiles for Information Leakage |
-| 4.2.4    | WSTG-INFO-004 | Enumerate Applications on Webserver |
-| 4.2.5    | WSTG-INFO-005 | Review Webpage Comments and Metadata for Information Leakage |
-| 4.2.6    | WSTG-INFO-006 | Identify application entry points |
-| 4.2.7    | WSTG-INFO-007 | Map execution paths through application |
-| 4.2.8    | WSTG-INFO-008 | Fingerprint Web Application Framework |
-| 4.2.9    | WSTG-INFO-009 | Fingerprint Web Application |
-| 4.2.10   | WSTG-INFO-010 | Map Application Architecture  |
+| 4.2.1    | WSTG-INFO-01 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
+| 4.2.2    | WSTG-INFO-02 | Fingerprint Web Server |
+| 4.2.3    | WSTG-INFO-03 | Review Webserver Metafiles for Information Leakage |
+| 4.2.4    | WSTG-INFO-04 | Enumerate Applications on Webserver |
+| 4.2.5    | WSTG-INFO-05 | Review Webpage Comments and Metadata for Information Leakage |
+| 4.2.6    | WSTG-INFO-06 | Identify application entry points |
+| 4.2.7    | WSTG-INFO-07 | Map execution paths through application |
+| 4.2.8    | WSTG-INFO-08 | Fingerprint Web Application Framework |
+| 4.2.9    | WSTG-INFO-09 | Fingerprint Web Application |
+| 4.2.10   | WSTG-INFO-10 | Map Application Architecture  |
 | **4.3**    | **WSTG-CONFIG** | **Configuration and Deploy Management Testing** |
 | 4.3.1    | WSTG-CONFIG-001 | Test Network/Infrastructure Configuration |
 | 4.3.2    | WSTG-CONFIG-002 | Test Application Platform Configuration |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -44,10 +44,10 @@ The following is the list of controls to test during the assessment:
 | 4.5.9    | WSTG-ATHN-09  | Testing for weak password change or reset functionalities |
 | 4.5.10   | WSTG-ATHN-10  | Testing for Weaker authentication in alternative channel |
 | **4.6**  | **WSTG-AUTHZ** | **Authorization Testing** |
-| 4.6.1    | WSTG-AUTHZ-001 | Testing Directory traversal/file include |
-| 4.6.2    | WSTG-AUTHZ-002 | Testing for bypassing authorization schema |
-| 4.6.3    | WSTG-AUTHZ-003 | Testing for Privilege Escalation |
-| 4.6.4    | WSTG-AUTHZ-004 | Testing for Insecure Direct Object References |
+| 4.6.1    | WSTG-ATHZ-01 | Testing Directory traversal/file include |
+| 4.6.2    | WSTG-ATHZ-02 | Testing for bypassing authorization schema |
+| 4.6.3    | WSTG-ATHZ-03 | Testing for Privilege Escalation |
+| 4.6.4    | WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
 | **4.7**  | **WSTG-SESS**  | **Session Management Testing** |
 | 4.7.1    | WSTG-SESS-001  | Testing for Bypassing Session Management Schema |
 | 4.7.2    | WSTG-SESS-002  | Testing for Cookies attributes |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -7,7 +7,7 @@ The following is the list of controls to test during the assessment:
 | **4.1** | **WSTG-INFO** | **Information Gathering** |
 | 4.1.1 | WSTG-INFO-01 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
 | 4.1.2 | WSTG-INFO-02 | Fingerprint Web Server |
-| 4.1.3 | WSTG-INFO-03 | Review Webserver Metafiles for Information |
+| 4.1.3 | WSTG-INFO-03 | Review Webserver Metafiles for Information Leakage |
 | 4.1.4 | WSTG-INFO-04 | Enumerate Applications on Webserver |
 | 4.1.5 | WSTG-INFO-05 | Review Webpage Comments and Metadata for Information Leakage |
 | 4.1.6 | WSTG-INFO-06 | Identify Application Entry Points |
@@ -16,7 +16,7 @@ The following is the list of controls to test during the assessment:
 | 4.1.9 | WSTG-INFO-09 | Fingerprint Web Application |
 | 4.1.10 | WSTG-INFO-10 | Map Application Architecture |
 | **4.2** | **WSTG-CONF** | **Configuration and Deploy Management Testing** |
-| 4.2.1 | WSTG-CONF-01 | Test Network/Infrastructure Configuration |
+| 4.2.1 | WSTG-CONF-01 | Test Network Infrastructure Configuration |
 | 4.2.2 | WSTG-CONF-02 | Test Application Platform Configuration |
 | 4.2.3 | WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
 | 4.2.4 | WSTG-CONF-04 | Backup and Unreferenced Files for Sensitive Information |
@@ -24,20 +24,21 @@ The following is the list of controls to test during the assessment:
 | 4.2.6 | WSTG-CONF-06 | Test HTTP Methods |
 | 4.2.7 | WSTG-CONF-07 | Test HTTP Strict Transport Security |
 | 4.2.8 | WSTG-CONF-08 | Test RIA Cross Domain Policy |
+| 4.2.9 | WSTG-CONF-09 | Test File Permission |
+| 4.2.10 | WSTG-CONF-10 | Test for Subdomain Takeover |
+| 4.2.11 | WSTG-CONF-11 | Test Cloud Storage |
 | **4.3** | **WSTG-IDNT** | **Identity Management Testing** |
 | 4.3.1 | WSTG-IDNT-01 | Test Role Definitions |
 | 4.3.2 | WSTG-IDNT-02 | Test User Registration Process |
 | 4.3.3 | WSTG-IDNT-03 | Test Account Provisioning Process |
 | 4.3.4 | WSTG-IDNT-04 | Testing for Account Enumeration and Guessable User Account |
 | 4.3.5 | WSTG-IDNT-05 | Testing for Weak or Unenforced Username Policy |
-| 4.3.6 | WSTG-IDNT-06 | Test Permissions of Guest/Training Accounts |
-| 4.3.7 | WSTG-IDNT-07 | Test Account Suspension/Resumption Process |
 | **4.4** | **WSTG-ATHN** | **Authentication Testing** |
 | 4.4.1 | WSTG-ATHN-01 | Testing for Credentials Transported over an Encrypted Channel |
-| 4.4.2 | WSTG-ATHN-02 | Testing for default credentials |
+| 4.4.2 | WSTG-ATHN-02 | Testing for Default Credentials |
 | 4.4.3 | WSTG-ATHN-03 | Testing for Weak Lock Out Mechanism |
 | 4.4.4 | WSTG-ATHN-04 | Testing for Bypassing Authentication Schema |
-| 4.4.5 | WSTG-ATHN-05 | Test Remember Password Functionality |
+| 4.4.5 | WSTG-ATHN-05 | Testing for Vulnerable Remember Password |
 | 4.4.6 | WSTG-ATHN-06 | Testing for Browser Cache Weakness |
 | 4.4.7 | WSTG-ATHN-07 | Testing for Weak Password Policy |
 | 4.4.8 | WSTG-ATHN-08 | Testing for Weak Security Question Answer |
@@ -63,14 +64,14 @@ The following is the list of controls to test during the assessment:
 | 4.7.3 | WSTG-INPV-03 | Testing for HTTP Verb Tampering |
 | 4.7.4 | WSTG-INPV-04 | Testing for HTTP Parameter pollution |
 | 4.7.5 | WSTG-INPV-05 | Testing for SQL Injection |
-| 4.7.5.1 | | Oracle Testing |
-| 4.7.5.2 | | MySQL Testing |
-| 4.7.5.3 | | SQL Server Testing |
-| 4.7.5.4 | | Testing PostgreSQL |
-| 4.7.5.5 | | MS Access Testing |
-| 4.7.5.6 | | Testing for NoSQL injection |
-| 4.7.5.7 | | Testing for ORM Injection |
-| 4.7.5.8 | | Testing for Client Side |
+| 4.7.5.1 | | Oracle |
+| 4.7.5.2 | | MySQL |
+| 4.7.5.3 | | SQL Server |
+| 4.7.5.4 | | PostgreSQL |
+| 4.7.5.5 | | MS Access |
+| 4.7.5.6 | | NoSQL |
+| 4.7.5.7 | | ORM |
+| 4.7.5.8 | | Client Side |
 | 4.7.6 | WSTG-INPV-06 | Testing for LDAP Injection |
 | 4.7.7 | WSTG-INPV-07 | Testing for XML Injection |
 | 4.7.8 | WSTG-INPV-08 | Testing for SSI Injection |
@@ -104,7 +105,7 @@ The following is the list of controls to test during the assessment:
 | 4.10.4 | WSTG-BUSL-04 | Test for Process Timing |
 | 4.10.5 | WSTG-BUSL-05 | Test Number of Times a Function Can be Used Limits |
 | 4.10.6 | WSTG-BUSL-06 | Testing for the Circumvention of Work Flows |
-| 4.10.7 | WSTG-BUSL-07 | Test Defenses Against Application Mis-use |
+| 4.10.7 | WSTG-BUSL-07 | Test Defenses Against Application Misuse |
 | 4.10.8 | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
 | 4.10.9 | WSTG-BUSL-09 | Test Upload of Malicious Files |
 | **4.11** | **WSTG-CLIENT** | **Client Side Testing** |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -33,16 +33,16 @@ The following is the list of controls to test during the assessment:
 | 4.4.6    | WSTG-IDNT-06  | Test Permissions of Guest/Training Accounts |
 | 4.4.7    | WSTG-IDNT-07  | Test Account Suspension/Resumption Process  |
 | **4.5**  | **WSTG-AUTHN**  | **Authentication Testing** |
-| 4.5.1    | WSTG-AUTHN-001  | Testing for Credentials Transported over an Encrypted Channel |
-| 4.5.2    | WSTG-AUTHN-002  | Testing for default credentials |
-| 4.5.3    | WSTG-AUTHN-003  | Testing for Weak lock out mechanism |
-| 4.5.4    | WSTG-AUTHN-004  | Testing for bypassing authentication schema |
-| 4.5.5    | WSTG-AUTHN-005  | Test remember password functionality |
-| 4.5.6    | WSTG-AUTHN-006  | Testing for Browser cache weakness |
-| 4.5.7    | WSTG-AUTHN-007  | Testing for Weak password policy |
-| 4.5.8    | WSTG-AUTHN-008  | Testing for Weak security question/answer |
-| 4.5.9    | WSTG-AUTHN-009  | Testing for weak password change or reset functionalities |
-| 4.5.10   | WSTG-AUTHN-010  | Testing for Weaker authentication in alternative channel |
+| 4.5.1    | WSTG-ATHN-01  | Testing for Credentials Transported over an Encrypted Channel |
+| 4.5.2    | WSTG-ATHN-02  | Testing for default credentials |
+| 4.5.3    | WSTG-ATHN-03  | Testing for Weak lock out mechanism |
+| 4.5.4    | WSTG-ATHN-04  | Testing for bypassing authentication schema |
+| 4.5.5    | WSTG-ATHN-05  | Test remember password functionality |
+| 4.5.6    | WSTG-ATHN-06  | Testing for Browser cache weakness |
+| 4.5.7    | WSTG-ATHN-07  | Testing for Weak password policy |
+| 4.5.8    | WSTG-ATHN-08  | Testing for Weak security question/answer |
+| 4.5.9    | WSTG-ATHN-09  | Testing for weak password change or reset functionalities |
+| 4.5.10   | WSTG-ATHN-10  | Testing for Weaker authentication in alternative channel |
 | **4.6**  | **WSTG-AUTHZ** | **Authorization Testing** |
 | 4.6.1    | WSTG-AUTHZ-001 | Testing Directory traversal/file include |
 | 4.6.2    | WSTG-AUTHZ-002 | Testing for bypassing authorization schema |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -89,9 +89,9 @@ The following is the list of controls to test during the assessment:
 | 4.9.1    | WSTG-ERRH-01    | Analysis of Error Codes |
 | 4.9.2    | WSTG-ERRH-02    | Analysis of Stack Traces |
 | **4.10** | **WSTG-CRYPST** | **Cryptography** |
-| 4.10.1   | WSTG-CRYPST-001 | Testing for Weak SSL/TSL Ciphers, Insufficient Transport Layer Protection  |
-| 4.10.2   | WSTG-CRYPST-002 | Testing for Padding Oracle |
-| 4.10.3   | WSTG-CRYPST-003 | Testing for Sensitive information sent via unencrypted channels |
+| 4.10.1   | WSTG-CRYP-01 | Testing for Weak SSL/TSL Ciphers, Insufficient Transport Layer Protection  |
+| 4.10.2   | WSTG-CRYP-02 | Testing for Padding Oracle |
+| 4.10.3   | WSTG-CRYP-03 | Testing for Sensitive information sent via unencrypted channels |
 | **4.11** | **WSTG-BUSLOGIC** | **Business Logic Testing** |
 | 4.11.1   | WSTG-BUSLOGIC-001 | Test Business Logic Data Validation |
 | 4.11.2   | WSTG-BUSLOGIC-002 | Test Ability to Forge Requests |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -93,15 +93,15 @@ The following is the list of controls to test during the assessment:
 | 4.10.2   | WSTG-CRYP-02 | Testing for Padding Oracle |
 | 4.10.3   | WSTG-CRYP-03 | Testing for Sensitive information sent via unencrypted channels |
 | **4.11** | **WSTG-BUSLOGIC** | **Business Logic Testing** |
-| 4.11.1   | WSTG-BUSLOGIC-001 | Test Business Logic Data Validation |
-| 4.11.2   | WSTG-BUSLOGIC-002 | Test Ability to Forge Requests |
-| 4.11.3   | WSTG-BUSLOGIC-003 | Test Integrity Checks |
-| 4.11.4   | WSTG-BUSLOGIC-004 | Test for Process Timing |
-| 4.11.5   | WSTG-BUSLOGIC-005 | Test Number of Times a Function Can be Used Limits |
-| 4.11.6   | WSTG-BUSLOGIC-006 | Testing for the Circumvention of Work Flows |
-| 4.11.7   | WSTG-BUSLOGIC-007 | Test Defenses Against Application Misuse |
-| 4.11.8   | WSTG-BUSLOGIC-008 | Test Upload of Unexpected File Types |
-| 4.11.9   | WSTG-BUSLOGIC-009 | Test Upload of Malicious Files |
+| 4.11.1   | WSTG-BUSL-01 | Test Business Logic Data Validation |
+| 4.11.2   | WSTG-BUSL-02 | Test Ability to Forge Requests |
+| 4.11.3   | WSTG-BUSL-03 | Test Integrity Checks |
+| 4.11.4   | WSTG-BUSL-04 | Test for Process Timing |
+| 4.11.5   | WSTG-BUSL-05 | Test Number of Times a Function Can be Used Limits |
+| 4.11.6   | WSTG-BUSL-06 | Testing for the Circumvention of Work Flows |
+| 4.11.7   | WSTG-BUSL-07 | Test Defenses Against Application Misuse |
+| 4.11.8   | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
+| 4.11.9   | WSTG-BUSL-09 | Test Upload of Malicious Files |
 | **4.12** | **WSTG-CLIENT** | **Client Side Testing** |
 | 4.12.1   | WSTG-CLIENT-001 | Testing for DOM based Cross Site Scripting |
 | 4.12.2   | WSTG-CLIENT-002 | Testing for JavaScript Execution |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -4,114 +4,120 @@ The following is the list of controls to test during the assessment:
 
 | Ref. No. | Category     | Test Name                  |
 |----------|--------------|----------------------------|
-| **4.2**  | **WSTG-INFO** | **Information Gathering**  |
-| 4.2.1    | WSTG-INFO-01 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
-| 4.2.2    | WSTG-INFO-02 | Fingerprint Web Server |
-| 4.2.3    | WSTG-INFO-03 | Review Webserver Metafiles for Information Leakage |
-| 4.2.4    | WSTG-INFO-04 | Enumerate Applications on Webserver |
-| 4.2.5    | WSTG-INFO-05 | Review Webpage Comments and Metadata for Information Leakage |
-| 4.2.6    | WSTG-INFO-06 | Identify application entry points |
-| 4.2.7    | WSTG-INFO-07 | Map execution paths through application |
-| 4.2.8    | WSTG-INFO-08 | Fingerprint Web Application Framework |
-| 4.2.9    | WSTG-INFO-09 | Fingerprint Web Application |
-| 4.2.10   | WSTG-INFO-10 | Map Application Architecture  |
-| **4.3**    | **WSTG-CONFIG** | **Configuration and Deploy Management Testing** |
-| 4.3.1    | WSTG-CONF-01 | Test Network/Infrastructure Configuration |
-| 4.3.2    | WSTG-CONF-02 | Test Application Platform Configuration |
-| 4.3.3    | WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
-| 4.3.4    | WSTG-CONF-04 | Backup and Unreferenced Files for Sensitive Information |
-| 4.3.5    | WSTG-CONF-05 | Enumerate Infrastructure and Application Admin Interfaces  |
-| 4.3.6    | WSTG-CONF-06 | Test HTTP Methods |
-| 4.3.7    | WSTG-CONF-07 | Test HTTP Strict Transport Security |
-| 4.3.8    | WSTG-CONF-08 | Test RIA cross domain policy |
-| **4.4**  | **WSTG-IDENT**  | **Identity Management Testing** |
-| 4.4.1    | WSTG-IDNT-01  | Test Role Definitions |
-| 4.4.2    | WSTG-IDNT-02  | Test User Registration Process |
-| 4.4.3    | WSTG-IDNT-03  | Test Account Provisioning Process |
-| 4.4.4    | WSTG-IDNT-04  | Testing for Account Enumeration and Guessable User Account |
-| 4.4.5    | WSTG-IDNT-05  | Testing for Weak or unenforced username policy |
-| 4.4.6    | WSTG-IDNT-06  | Test Permissions of Guest/Training Accounts |
-| 4.4.7    | WSTG-IDNT-07  | Test Account Suspension/Resumption Process  |
-| **4.5**  | **WSTG-AUTHN**  | **Authentication Testing** |
-| 4.5.1    | WSTG-ATHN-01  | Testing for Credentials Transported over an Encrypted Channel |
-| 4.5.2    | WSTG-ATHN-02  | Testing for default credentials |
-| 4.5.3    | WSTG-ATHN-03  | Testing for Weak lock out mechanism |
-| 4.5.4    | WSTG-ATHN-04  | Testing for bypassing authentication schema |
-| 4.5.5    | WSTG-ATHN-05  | Test remember password functionality |
-| 4.5.6    | WSTG-ATHN-06  | Testing for Browser cache weakness |
-| 4.5.7    | WSTG-ATHN-07  | Testing for Weak password policy |
-| 4.5.8    | WSTG-ATHN-08  | Testing for Weak security question/answer |
-| 4.5.9    | WSTG-ATHN-09  | Testing for weak password change or reset functionalities |
-| 4.5.10   | WSTG-ATHN-10  | Testing for Weaker authentication in alternative channel |
-| **4.6**  | **WSTG-AUTHZ** | **Authorization Testing** |
-| 4.6.1    | WSTG-ATHZ-01 | Testing Directory traversal/file include |
-| 4.6.2    | WSTG-ATHZ-02 | Testing for bypassing authorization schema |
-| 4.6.3    | WSTG-ATHZ-03 | Testing for Privilege Escalation |
-| 4.6.4    | WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
-| **4.7**  | **WSTG-SESS**  | **Session Management Testing** |
-| 4.7.1    | WSTG-SESS-01  | Testing for Bypassing Session Management Schema |
-| 4.7.2    | WSTG-SESS-02  | Testing for Cookies attributes |
-| 4.7.3    | WSTG-SESS-03  | Testing for Session Fixation |
-| 4.7.4    | WSTG-SESS-04  | Testing for Exposed Session Variables |
-| 4.7.5    | WSTG-SESS-05  | Testing for Cross Site Request Forgery |
-| 4.7.6    | WSTG-SESS-06  | Testing for logout functionality |
-| 4.7.7    | WSTG-SESS-07  | Test Session Timeout |
-| 4.7.8    | WSTG-SESS-08  | Testing for Session puzzling |
-| **4.8**  | **WSTG-INPVAL** | **Data Validation Testing** |
-| 4.8.1    | WSTG-INPV-01 | Testing for Reflected Cross Site Scripting |
-| 4.8.2    | WSTG-INPV-02 | Testing for Stored Cross Site Scripting |
-| 4.8.3    | WSTG-INPV-03 | Testing for HTTP Verb Tampering |
-| 4.8.4    | WSTG-INPV-04 | Testing for HTTP Parameter pollution |
-| 4.8.5    | WSTG-INPV-05 | Testing for SQL Injection |
-| 4.8.5.1  |                | Oracle Testing |
-| 4.8.5.2  |                | MySQL Testing |
-| 4.8.5.3  |                | SQL Server Testing |
-| 4.8.5.4  |                | Testing PostgreSQL |
-| 4.8.5.5  |                | MS Access Testing |
-| 4.8.5.6  |                | Testing for NoSQL injection |
-| 4.8.6    | WSTG-INPV-06 | Testing for LDAP Injection |
-| 4.8.7    | WSTG-INPV-07 | Testing for ORM Injection |
-| 4.8.8    | WSTG-INPV-08 | Testing for XML Injection |
-| 4.8.9    | WSTG-INPV-09 | Testing for SSI Injection |
-| 4.8.10   | WSTG-INPV-10 | Testing for XPath Injection |
-| 4.8.11   | WSTG-INPV-11 | IMAP/SMTP Injection |
-| 4.8.12   | WSTG-INPV-12 | Testing for Code Injection |
-| 4.8.12.1 |                | Testing for Local File Inclusion |
-| 4.8.12.2 |                | Testing for Remote File Inclusion |
-| 4.8.13   | WSTG-INPV-13 | Testing for Command Injection |
-| 4.8.14   | WSTG-INPV-14 | Testing for Buffer overflow |
-| 4.8.14.1 |                | Testing for Heap overflow |
-| 4.8.14.2 |                | Testing for Stack overflow |
-| 4.8.14.3 |                | Testing for Format string |
-| 4.8.15   | WSTG-INPV-15 | Testing for incubated vulnerabilities |
-| 4.8.16   | WSTG-INPV-16 | Testing for HTTP Splitting/Smuggling |
-| **4.9**  | **WSTG-ERR**    | **Error Handling** |
-| 4.9.1    | WSTG-ERRH-01    | Analysis of Error Codes |
-| 4.9.2    | WSTG-ERRH-02    | Analysis of Stack Traces |
-| **4.10** | **WSTG-CRYPST** | **Cryptography** |
-| 4.10.1   | WSTG-CRYP-01 | Testing for Weak SSL/TSL Ciphers, Insufficient Transport Layer Protection  |
-| 4.10.2   | WSTG-CRYP-02 | Testing for Padding Oracle |
-| 4.10.3   | WSTG-CRYP-03 | Testing for Sensitive information sent via unencrypted channels |
-| **4.11** | **WSTG-BUSLOGIC** | **Business Logic Testing** |
-| 4.11.1   | WSTG-BUSL-01 | Test Business Logic Data Validation |
-| 4.11.2   | WSTG-BUSL-02 | Test Ability to Forge Requests |
-| 4.11.3   | WSTG-BUSL-03 | Test Integrity Checks |
-| 4.11.4   | WSTG-BUSL-04 | Test for Process Timing |
-| 4.11.5   | WSTG-BUSL-05 | Test Number of Times a Function Can be Used Limits |
-| 4.11.6   | WSTG-BUSL-06 | Testing for the Circumvention of Work Flows |
-| 4.11.7   | WSTG-BUSL-07 | Test Defenses Against Application Misuse |
-| 4.11.8   | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
-| 4.11.9   | WSTG-BUSL-09 | Test Upload of Malicious Files |
-| **4.12** | **WSTG-CLIENT** | **Client Side Testing** |
-| 4.12.1   | WSTG-CLNT-01 | Testing for DOM based Cross Site Scripting |
-| 4.12.2   | WSTG-CLNT-02 | Testing for JavaScript Execution |
-| 4.12.3   | WSTG-CLNT-03 | Testing for HTML Injection |
-| 4.12.4   | WSTG-CLNT-04 | Testing for Client Side URL Redirect |
-| 4.12.5   | WSTG-CLNT-05 | Testing for CSS Injection |
-| 4.12.6   | WSTG-CLNT-06 | Testing for Client Side Resource Manipulation |
-| 4.12.7   | WSTG-CLNT-07 | Test Cross Origin Resource Sharing |
-| 4.12.8   | WSTG-CLNT-08 | Testing for Cross Site Flashing |
-| 4.12.9   | WSTG-CLNT-09 | Testing for Clickjacking |
-| 4.12.10  | WSTG-CLNT-10 | Testing WebSockets |
-| 4.12.11  | WSTG-CLNT-11 | Test Web Messaging |
-| 4.12.12  | WSTG-CLNT-12 | Test Local Storage |
+| **4.1** | **WSTG-INFO** | **Information Gathering** |
+| 4.1.1 | WSTG-INFO-01 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
+| 4.1.2 | WSTG-INFO-02 | Fingerprint Web Server |
+| 4.1.3 | WSTG-INFO-03 | Review Webserver Metafiles for Information |
+| 4.1.4 | WSTG-INFO-04 | Enumerate Applications on Webserver |
+| 4.1.5 | WSTG-INFO-05 | Review Webpage Comments and Metadata for Information Leakage |
+| 4.1.6 | WSTG-INFO-06 | Identify Application Entry Points |
+| 4.1.7 | WSTG-INFO-07 | Map Execution Paths Through Application |
+| 4.1.8 | WSTG-INFO-09 | Fingerprint Web Application Framework |
+| 4.1.9 | WSTG-INFO-09 | Fingerprint Web Application |
+| 4.1.10 | WSTG-INFO-10 | Map Application Architecture |
+| **4.2** | **WSTG-CONF** | **Configuration and Deploy Management Testing** |
+| 4.2.1 | WSTG-CONF-01 | Test Network/Infrastructure Configuration |
+| 4.2.2 | WSTG-CONF-02 | Test Application Platform Configuration |
+| 4.2.3 | WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
+| 4.2.4 | WSTG-CONF-04 | Backup and Unreferenced Files for Sensitive Information |
+| 4.2.5 | WSTG-CONF-05 | Enumerate Infrastructure and Application Admin Interfaces |
+| 4.2.6 | WSTG-CONF-06 | Test HTTP Methods |
+| 4.2.7 | WSTG-CONF-07 | Test HTTP Strict Transport Security |
+| 4.2.8 | WSTG-CONF-08 | Test RIA Cross Domain Policy |
+| **4.3** | **WSTG-IDNT** | **Identity Management Testing** |
+| 4.3.1 | WSTG-IDNT-01 | Test Role Definitions |
+| 4.3.2 | WSTG-IDNT-02 | Test User Registration Process |
+| 4.3.3 | WSTG-IDNT-03 | Test Account Provisioning Process |
+| 4.3.4 | WSTG-IDNT-04 | Testing for Account Enumeration and Guessable User Account |
+| 4.3.5 | WSTG-IDNT-05 | Testing for Weak or Unenforced Username Policy |
+| 4.3.6 | WSTG-IDNT-06 | Test Permissions of Guest/Training Accounts |
+| 4.3.7 | WSTG-IDNT-07 | Test Account Suspension/Resumption Process |
+| **4.4** | **WSTG-ATHN** | **Authentication Testing** |
+| 4.4.1 | WSTG-ATHN-01 | Testing for Credentials Transported over an Encrypted Channel |
+| 4.4.2 | WSTG-ATHN-02 | Testing for default credentials |
+| 4.4.3 | WSTG-ATHN-03 | Testing for Weak Lock Out Mechanism |
+| 4.4.4 | WSTG-ATHN-04 | Testing for Bypassing Authentication Schema |
+| 4.4.5 | WSTG-ATHN-05 | Test Remember Password Functionality |
+| 4.4.6 | WSTG-ATHN-06 | Testing for Browser Cache Weakness |
+| 4.4.7 | WSTG-ATHN-07 | Testing for Weak Password Policy |
+| 4.4.8 | WSTG-ATHN-08 | Testing for Weak Security Question Answer |
+| 4.4.9 | WSTG-ATHN-09 | Testing for Weak Password Change or Reset Functionalities |
+| 4.4.10 | WSTG-ATHN-10 | Testing for Weaker Authentication in Alternative Channel |
+| **4.5** | **WSTG-ATHZ** | **Authorization Testing** |
+| 4.5.1 | WSTG-ATHZ-01 | Testing Directory Traversal - File Include |
+| 4.5.2 | WSTG-ATHZ-02 | Testing for Bypassing Authorization Schema |
+| 4.5.3 | WSTG-ATHZ-03 | Testing for Privilege Escalation |
+| 4.5.4 | WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
+| **4.6** | **WSTG-SESS** | **Session Management Testing** |
+| 4.6.1 | WSTG-SESS-01 | Testing for Bypassing Session Management Schema |
+| 4.6.2 | WSTG-SESS-02 | Testing for Cookies Attributes |
+| 4.6.3 | WSTG-SESS-03 | Testing for Session Fixation |
+| 4.6.4 | WSTG-SESS-04 | Testing for Exposed Session Variables |
+| 4.6.5 | WSTG-SESS-05 | Testing for Cross Site Request Forgery |
+| 4.6.6 | WSTG-SESS-06 | Testing for Logout Functionality |
+| 4.6.7 | WSTG-SESS-07 | Test Session Timeout |
+| 4.6.8 | WSTG-SESS-08 | Testing for Session Puzzling |
+| **4.7** | **WSTG-INPV** |**Input Validation Testing** |
+| 4.7.1 | WSTG-INPV-01 | Testing for Reflected Cross Site Scripting |
+| 4.7.2 | WSTG-INPV-02 | Testing for Stored Cross Site Scripting |
+| 4.7.3 | WSTG-INPV-03 | Testing for HTTP Verb Tampering |
+| 4.7.4 | WSTG-INPV-04 | Testing for HTTP Parameter pollution |
+| 4.7.5 | WSTG-INPV-05 | Testing for SQL Injection |
+| 4.7.5.1 | | Oracle Testing |
+| 4.7.5.2 | | MySQL Testing   |
+| 4.7.5.3 | | SQL Server Testing |
+| 4.7.5.4 | | Testing PostgreSQL |
+| 4.7.5.5 | | MS Access Testing |
+| 4.7.5.6 | | Testing for NoSQL injection |
+| 4.7.5.7 | | Testing for ORM Injection |
+| 4.7.5.8 | | Testing for Client Side |
+| 4.7.6 | WSTG-INPV-06 | Testing for LDAP Injection |
+| 4.7.7 | WSTG-INPV-07 | Testing for XML Injection |
+| 4.7.8 | WSTG-INPV-08 | Testing for SSI Injection |
+| 4.7.9 | WSTG-INPV-09 | Testing for XPath Injection |
+| 4.7.10 | WSTG-INPV-10 | IMAP/SMTP Injection |
+| 4.7.11 | WSTG-INPV-11 | Testing for Code Injection |
+| 4.7.11.1 | |Testing for Local File Inclusion |
+| 4.7.11.2 | |Testing for Remote File Inclusion |
+| 4.7.12 | WSTG-INPV-12 | Testing for Command Injection |
+| 4.7.13 | WSTG-INPV-13 | Testing for Buffer overflow |
+| 4.7.13.1 | | Testing for Heap Overflow |
+| 4.7.13.2 | | Testing for Stack Overflow |
+| 4.7.13.3 | | Testing for Format String |
+| 4.7.14 | WSTG-INPV-14 | Testing for Incubated Vulnerabilities |
+| 4.7.15 | WSTG-INPV-15 | Testing for HTTP Splitting/Smuggling |
+| 4.7.16 | WSTG-INPV-16 | Testing for HTTP Incoming Requests |
+| 4.7.17 | WSTG-INPV-17 | Testing for Host Header Injection |
+| 4.7.18 | WSTG-INPV-18 | Testing for Server Side Template Injection |
+| **4.8** | **WSTG-ERRH**  |**Error Handling** |
+| 4.8.1 | WSTG-ERRH-01  | Analysis of Error Codes |
+| 4.8.2 | WSTG-ERRH-02  | Analysis of Stack Traces |
+| **4.9** | **WSTG-CRYP** | **Cryptography** |
+| 4.9.1 | WSTG-CRYP-01 | Testing for Weak Cryptography |
+| 4.9.2 | WSTG-CRYP-02 | Testing for Padding Oracle |
+| 4.9.3 | WSTG-CRYP-03 | Testing for Sensitive Information Sent Via Unencrypted Channels |
+| 4.9.4 | WSTG-CRYP-04 | Testing for Weak Encryption |
+| **4.10** | **WSTG-BUSLOGIC** | **Business Logic Testing** |
+| 4.10.1 | WSTG-BUSL-01 | Test Business Logic Data Validation |
+| 4.10.2 | WSTG-BUSL-02 | Test Ability to Forge Requests |
+| 4.10.3 | WSTG-BUSL-03 | Test Integrity Checks |
+| 4.10.4 | WSTG-BUSL-04 | Test for Process Timing |
+| 4.10.5 | WSTG-BUSL-05 | Test Number of Times a Function Can be Used Limits |
+| 4.10.6 | WSTG-BUSL-06 | Testing for the Circumvention of Work Flows |
+| 4.10.7 | WSTG-BUSL-07 | Test Defenses Against Application Mis-use |
+| 4.10.8 | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
+| 4.10.9 | WSTG-BUSL-09 | Test Upload of Malicious Files |
+| **4.11** | **WSTG-CLIENT** | **Client Side Testing** |
+| 4.11.1 | WSTG-CLNT-01 | Testing for DOM based Cross Site Scripting |
+| 4.11.2 | WSTG-CLNT-02 | Testing for JavaScript Execution |
+| 4.11.3 | WSTG-CLNT-03 | Testing for HTML Injection |
+| 4.11.4 | WSTG-CLNT-04 | Testing for Client Side URL Redirect |
+| 4.11.5 | WSTG-CLNT-05 | Testing for CSS Injection |
+| 4.11.6 | WSTG-CLNT-06 | Testing for Client Side Resource Manipulation |
+| 4.11.7 | WSTG-CLNT-07 | Test Cross Origin Resource Sharing |
+| 4.11.8 | WSTG-CLNT-08 | Testing for Cross Site Flashing |
+| 4.11.9 | WSTG-CLNT-09 | Testing for Clickjacking |
+| 4.11.10 | WSTG-CLNT-10 | Testing WebSockets |
+| 4.11.11 | WSTG-CLNT-11 | Test Web Messaging |
+| 4.11.12 | WSTG-CLNT-12 | Test Local Storage |
+| 4.11.13 | WSTG-CLNT-13 | Testing for Cross Site Script Inclusion |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -103,15 +103,15 @@ The following is the list of controls to test during the assessment:
 | 4.11.8   | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
 | 4.11.9   | WSTG-BUSL-09 | Test Upload of Malicious Files |
 | **4.12** | **WSTG-CLIENT** | **Client Side Testing** |
-| 4.12.1   | WSTG-CLIENT-001 | Testing for DOM based Cross Site Scripting |
-| 4.12.2   | WSTG-CLIENT-002 | Testing for JavaScript Execution |
-| 4.12.3   | WSTG-CLIENT-003 | Testing for HTML Injection |
-| 4.12.4   | WSTG-CLIENT-004 | Testing for Client Side URL Redirect |
-| 4.12.5   | WSTG-CLIENT-005 | Testing for CSS Injection |
-| 4.12.6   | WSTG-CLIENT-006 | Testing for Client Side Resource Manipulation |
-| 4.12.7   | WSTG-CLIENT-007 | Test Cross Origin Resource Sharing |
-| 4.12.8   | WSTG-CLIENT-008 | Testing for Cross Site Flashing |
-| 4.12.9   | WSTG-CLIENT-009 | Testing for Clickjacking |
-| 4.12.10  | WSTG-CLIENT-010 | Testing WebSockets |
-| 4.12.11  | WSTG-CLIENT-011 | Test Web Messaging |
-| 4.12.12  | WSTG-CLIENT-012 | Test Local Storage |
+| 4.12.1   | WSTG-CLNT-01 | Testing for DOM based Cross Site Scripting |
+| 4.12.2   | WSTG-CLNT-02 | Testing for JavaScript Execution |
+| 4.12.3   | WSTG-CLNT-03 | Testing for HTML Injection |
+| 4.12.4   | WSTG-CLNT-04 | Testing for Client Side URL Redirect |
+| 4.12.5   | WSTG-CLNT-05 | Testing for CSS Injection |
+| 4.12.6   | WSTG-CLNT-06 | Testing for Client Side Resource Manipulation |
+| 4.12.7   | WSTG-CLNT-07 | Test Cross Origin Resource Sharing |
+| 4.12.8   | WSTG-CLNT-08 | Testing for Cross Site Flashing |
+| 4.12.9   | WSTG-CLNT-09 | Testing for Clickjacking |
+| 4.12.10  | WSTG-CLNT-10 | Testing WebSockets |
+| 4.12.11  | WSTG-CLNT-11 | Test Web Messaging |
+| 4.12.12  | WSTG-CLNT-12 | Test Local Storage |

--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -25,13 +25,13 @@ The following is the list of controls to test during the assessment:
 | 4.3.7    | WSTG-CONF-07 | Test HTTP Strict Transport Security |
 | 4.3.8    | WSTG-CONF-08 | Test RIA cross domain policy |
 | **4.4**  | **WSTG-IDENT**  | **Identity Management Testing** |
-| 4.4.1    | WSTG-IDENT-001  | Test Role Definitions |
-| 4.4.2    | WSTG-IDENT-002  | Test User Registration Process |
-| 4.4.3    | WSTG-IDENT-003  | Test Account Provisioning Process |
-| 4.4.4    | WSTG-IDENT-004  | Testing for Account Enumeration and Guessable User Account |
-| 4.4.5    | WSTG-IDENT-005  | Testing for Weak or unenforced username policy |
-| 4.4.6    | WSTG-IDENT-006  | Test Permissions of Guest/Training Accounts |
-| 4.4.7    | WSTG-IDENT-007  | Test Account Suspension/Resumption Process  |
+| 4.4.1    | WSTG-IDNT-01  | Test Role Definitions |
+| 4.4.2    | WSTG-IDNT-02  | Test User Registration Process |
+| 4.4.3    | WSTG-IDNT-03  | Test Account Provisioning Process |
+| 4.4.4    | WSTG-IDNT-04  | Testing for Account Enumeration and Guessable User Account |
+| 4.4.5    | WSTG-IDNT-05  | Testing for Weak or unenforced username policy |
+| 4.4.6    | WSTG-IDNT-06  | Test Permissions of Guest/Training Accounts |
+| 4.4.7    | WSTG-IDNT-07  | Test Account Suspension/Resumption Process  |
 | **4.5**  | **WSTG-AUTHN**  | **Authentication Testing** |
 | 4.5.1    | WSTG-AUTHN-001  | Testing for Credentials Transported over an Encrypted Channel |
 | 4.5.2    | WSTG-AUTHN-002  | Testing for default credentials |

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-001|
+|WSTG-INFO-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-002|
+|WSTG-INFO-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-003|
+|WSTG-INFO-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-004|
+|WSTG-INFO-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-005|
+|WSTG-INFO-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-006|
+|WSTG-INFO-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-007|
+|WSTG-INFO-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-008|
+|WSTG-INFO-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-009|
+|WSTG-INFO-09|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-INFO-010|
+|WSTG-INFO-10|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-001|
+|WSTG-CONF-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-002|
+|WSTG-CONF-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-003|
+|WSTG-CONF-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-004|
+|WSTG-CONF-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-005|
+|WSTG-CONF-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-006|
+|WSTG-CONF-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-007|
+|WSTG-CONF-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-008|
+|WSTG-CONF-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-009|
+|WSTG-CONF-09|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-010|
+|WSTG-CONF-10|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CONFIG-011|
+|WSTG-CONF-11|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions.md
+++ b/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-IDENT-001|
+|WSTG-IDNT-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process.md
+++ b/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-IDENT-002|
+|WSTG-IDNT-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process.md
+++ b/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-IDENT-003|
+|WSTG-IDNT-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md
+++ b/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-IDENT-004|
+|WSTG-IDNT-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy.md
+++ b/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-IDENT-005|
+|WSTG-IDNT-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-001|
+|WSTG-ATHN-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-002|
+|WSTG-ATHN-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -31,7 +31,7 @@ When facing applications where we do not have a list of default and common user 
 
 Many applications have verbose error messages that inform the site users as to the validity of entered usernames. This information will be helpful when testing for default or guessable user accounts. Such functionality can be found, for example, on the log in page, password reset and forgotten password page, and sign up page. Once you have found a default username you could also start guessing passwords for this account.
 
-More information about this procedure can be found in the section [Testing for User Enumeration and Guessable User Account](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) and in the section [Testing for Weak password policy](../4.5_Authentication_Testing/07-Testing_for_Weak_Password_Policy.md).
+More information about this procedure can be found in the section [Testing for User Enumeration and Guessable User Account](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) and in the section [Testing for Weak password policy](07-Testing_for_Weak_Password_Policy.md).
 
 Since these types of default credentials are often bound to administrative accounts you can proceed in this manner:
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-003|
+|WSTG-ATHN-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-004|
+|WSTG-ATHN-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-005|
+|WSTG-ATHN-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-006|
+|WSTG-ATHN-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-007|
+|WSTG-ATHN-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-008|
+|WSTG-ATHN-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-009|
+|WSTG-ATHN-09|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHN-010|
+|WSTG-ATHN-10|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHZ-001|
+|WSTG-ATHZ-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHZ-002|
+|WSTG-ATHZ-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHZ-003|
+|WSTG-ATHZ-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References.md
@@ -2,7 +2,7 @@
 
 |ID            |
 |--------------|
-|WSTG-AUTHZ-004|
+|WSTG-ATHZ-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-001|
+|WSTG-SESS-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-002|
+|WSTG-SESS-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-003|
+|WSTG-SESS-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-004|
+|WSTG-SESS-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_CSRF.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_CSRF.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-005|
+|WSTG-SESS-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-006|
+|WSTG-SESS-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-007|
+|WSTG-SESS-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling.md
@@ -2,7 +2,7 @@
 
 |ID           |
 |-------------|
-|WSTG-SESS-008|
+|WSTG-SESS-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-001|
+|WSTG-INPV-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-002|
+|WSTG-INPV-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-003|
+|WSTG-INPV-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-004|
+|WSTG-INPV-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -573,6 +573,11 @@ Technology specific Testing Guide pages have been created for the following DBMS
 - [Oracle](05.1-Testing_for_Oracle.md)
 - [MySQL](05.2-Testing_for_MySQL.md)
 - [SQL Server](05.3-Testing_for_SQL_Server.md)
+- [PostgreSQL](05.4-Testing_PostgreSQL.md)
+- [MS Access](05.5-Testing_for_MS_Access.md)
+- [NoSQL](05.6-Testing_for_NoSQL_Injection.md)
+- [ORM](05.7-Testing_for_ORM_Injection.md)
+- [Client Side](05.8-Testing_for_Client_Side.md)
 
 ### Whitepapers
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-005|
+|WSTG-INPV-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -570,9 +570,9 @@ For generic input validation security, refer to the [Input Validation CheatSheet
 
 Technology specific Testing Guide pages have been created for the following DBMSs:
 
-- [Oracle](4.8.5.1_Testing_for_Oracle.md)
-- [MySQL](4.8.5.2_Testing_for_MySQL.md)
-- [SQL Server](4.8.5.3_Testing_for_SQL_Server.md)
+- [Oracle](05.1-Testing_for_Oracle.md)
+- [MySQL](05.2-Testing_for_MySQL.md)
+- [SQL Server](05.3-Testing_for_SQL_Server.md)
 
 ### Whitepapers
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-006|
+|WSTG-INPV-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-007|
+|WSTG-INPV-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-008|
+|WSTG-INPV-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection.md
@@ -61,4 +61,4 @@ If there is no knowledge about the XML data internal details and if the applicat
 ### Whitepapers
 
 - [Amit Klein: “Blind XPath Injection”](http://dl.packetstormsecurity.net/papers/bypass/Blind_XPath_Injection_20040518.pdf)
-- [XPath 1.0 specifications](http://www.w3.org/TR/xpath)
+- [XPath 1.0 specifications](https://www.w3.org/TR/1999/REC-xpath-19991116/)

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-009|
+|WSTG-INPV-09|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-010|
+|WSTG-INPV-10|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11-Testing_for_Code_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11-Testing_for_Code_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-011|
+|WSTG-INPV-11|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-012|
+|WSTG-INPV-12|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Buffer_Overflow.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Buffer_Overflow.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-013|
+|WSTG-INPV-13|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-014|
+|WSTG-INPV-14|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-015|
+|WSTG-INPV-15|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-016|
+|WSTG-INPV-16|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-017|
+|WSTG-INPV-17|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-INPVAL-018|
+|WSTG-INPV-18|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_for_Error_Code.md
+++ b/document/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_for_Error_Code.md
@@ -2,7 +2,7 @@
 
 |ID          |
 |------------|
-|WSTG-ERR-001|
+|WSTG-ERRH-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces.md
+++ b/document/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces.md
@@ -2,7 +2,7 @@
 
 |ID          |
 |------------|
-|WSTG-ERR-002|
+|WSTG-ERRH-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md
@@ -135,7 +135,7 @@ The following standards can be used as reference while assessing SSL servers:
 - OWASP has a lot of resources about SSL/TLS Security:
   - [Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html).
   - [OWASP Top 10 2017 A3-Sensitive Data Exposure](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure).
-  - [OWASP ASVS - Verification V10](https://code.google.com/p/owasp-asvs/wiki/Verification_V10).
+  - [OWASP ASVS - Verification V9](https://github.com/OWASP/ASVS/blob/master/4.0/en/0x17-V9-Communications.md).
   - [OWASP Application Security FAQ - Cryptography/SSL](https://owasp.org/www-community/OWASP_Application_Security_FAQ#cryptographyssl).
 
 Some tools and scanners both free (e.g. [SSLAudit](https://code.google.com/p/sslaudit/) or [SSLScan](https://sourceforge.net/projects/sslscan/)) and commercial (e.g. [Tenable Nessus](https://www.tenable.com/products/nessus)), can be used to assess SSL/TLS vulnerabilities. But due to evolution of these vulnerabilities a good way to test is to check them manually with [OpenSSL](https://www.openssl.org/) or use the tool’s output as an input for manual evaluation using the references.

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CRYPST-001|
+|WSTG-CRYP-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md
@@ -988,7 +988,7 @@ Checking localhost:443 for ROBUST use of anti-caching mechanism ...
 Robust Solution:
 
     - Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0, s-maxage=0
-    - Ref: https://www.owasp.org/index.php/Testing_for_Browser_cache_weakness_(WSTG-AUTHN-006)
+    - Ref: https://wiki.owasp.org/index.php/Testing_for_Browser_cache_weakness_(OTG-AUTHN-006)
            https://docs.microsoft.com/en-us/iis/configuration/system.webserver/staticcontent/clientcache
 
 =====================================

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CRYPST-002|
+|WSTG-CRYP-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Sensitive data must be protected when it is transmitted through the network. If data is transmitted over HTTPS or encrypted in another way the protection mechanism must not have limitations or vulnerabilities, as explained in the broader article "[Testing for Weak SSL/TLS Ciphers, Insufficient Transport Layer Protection (WSTG-CRYPST-001)](01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md)" and in other OWASP documentation:
+Sensitive data must be protected when it is transmitted through the network. If data is transmitted over HTTPS or encrypted in another way the protection mechanism must not have limitations or vulnerabilities, as explained in the broader article "[Testing for Weak SSL/TLS Ciphers, Insufficient Transport Layer Protection](01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md)" and in other OWASP documentation:
 
 - [OWASP Top 10 2017 A3-Sensitive Data Exposure](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure).
 - [OWASP ASVS - Verification V10](https://code.google.com/p/owasp-asvs/wiki/Verification_V10).

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CRYPST-003|
+|WSTG-CRYP-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
@@ -9,7 +9,7 @@
 Sensitive data must be protected when it is transmitted through the network. If data is transmitted over HTTPS or encrypted in another way the protection mechanism must not have limitations or vulnerabilities, as explained in the broader article "[Testing for Weak SSL/TLS Ciphers, Insufficient Transport Layer Protection](01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md)" and in other OWASP documentation:
 
 - [OWASP Top 10 2017 A3-Sensitive Data Exposure](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure).
-- [OWASP ASVS - Verification V10](https://code.google.com/p/owasp-asvs/wiki/Verification_V10).
+- [OWASP ASVS - Verification V9](https://github.com/OWASP/ASVS/blob/master/4.0/en/0x17-V9-Communications.md).
 - [Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html).
 
 As a rule of thumb if data must be protected when it is stored, this data must also be protected during transmission. Some examples for sensitive data are:

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CRYPST-004|
+|WSTG-CRYP-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-001|
+|WSTG-BUSL-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-002|
+|WSTG-BUSL-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-003|
+|WSTG-BUSL-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-004|
+|WSTG-BUSL-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-005|
+|WSTG-BUSL-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-006|
+|WSTG-BUSL-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows.md
@@ -71,7 +71,7 @@ An electronic bulletin board system may be designed to ensure that initial posts
 
 ## References
 
-[OWASP Abuse Case Cheat Sheet](https://owasp.org/www-project-cheat-sheets/cheatsheets/Abuse_Case_Cheat_Sheet.html)
+[OWASP Abuse Case Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Abuse_Case_Cheat_Sheet.html)
 
 [CWE-840: Business Logic Errors](https://cwe.mitre.org/data/definitions/840.html)
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-007|
+|WSTG-BUSL-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-008|
+|WSTG-BUSL-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files.md
@@ -2,7 +2,7 @@
 
 |ID               |
 |-----------------|
-|WSTG-BUSLOGIC-009|
+|WSTG-BUSL-09|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-001|
+|WSTG-CLNT-01|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/02-Testing_for_JavaScript_Execution.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/02-Testing_for_JavaScript_Execution.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-002|
+|WSTG-CLNT-02|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/03-Testing_for_HTML_Injection.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/03-Testing_for_HTML_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-003|
+|WSTG-CLNT-03|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/04-Testing_for_Client_Side_URL_Redirect.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/04-Testing_for_Client_Side_URL_Redirect.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-004|
+|WSTG-CLNT-04|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-005|
+|WSTG-CLNT-05|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/06-Testing_for_Client_Side_Resource_Manipulation.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/06-Testing_for_Client_Side_Resource_Manipulation.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-006|
+|WSTG-CLNT-06|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/07-Testing_Cross_Origin_Resource_Sharing.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/07-Testing_Cross_Origin_Resource_Sharing.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-007|
+|WSTG-CLNT-07|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/08-Testing_for_Cross_Site_Flashing.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/08-Testing_for_Cross_Site_Flashing.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-008|
+|WSTG-CLNT-08|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-009|
+|WSTG-CLNT-09|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-010|
+|WSTG-CLNT-10|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets.md
@@ -36,7 +36,7 @@ As with any data originating from untrusted sources, the data should be properly
 
 3. Confidentiality and Integrity.
    - Check that the WebSocket connection is using SSL to transport sensitive information `wss://`.
-   - Check the SSL Implementation for security issues (Valid Certificate, BEAST, CRIME, RC4, etc). Refer to the [Testing for Weak SSL/TLS Ciphers, Insufficient Transport Layer Protection (WSTG-CRYPST-001)](../09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md) section of this guide.
+   - Check the SSL Implementation for security issues (Valid Certificate, BEAST, CRIME, RC4, etc). Refer to the [Testing for Weak SSL/TLS Ciphers, Insufficient Transport Layer Protection](../09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.md) section of this guide.
 
 4. Authentication.
    - WebSockets do not handle authentication, normal black-box authentication tests should be carried out. Refer to the [Authentication Testing](../04-Authentication_Testing/README.md) sections of this guide.

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/11-Testing_Web_Messaging.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/11-Testing_Web_Messaging.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-011|
+|WSTG-CLNT-11|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/12-Testing_Web_Storage.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/12-Testing_Web_Storage.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-012|
+|WSTG-CLNT-12|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/13-Testing_for_Cross_Site_Script_Inclusion.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/13-Testing_for_Cross_Site_Script_Inclusion.md
@@ -2,7 +2,7 @@
 
 |ID             |
 |---------------|
-|WSTG-CLIENT-013|
+|WSTG-CLNT-13|
 
 ## Summary
 

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -148,18 +148,18 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
 | WSTG-BUSL-09 | Test Upload of Malicious Files |
 | **WSTG-CLIENT** | **Client Side Testing** |
-| WSTG-CLIENT-001 | Testing for DOM based Cross Site Scripting |
-| WSTG-CLIENT-002 | Testing for JavaScript Execution |
-| WSTG-CLIENT-003 | Testing for HTML Injection |
-| WSTG-CLIENT-004 | Testing for Client Side URL Redirect |
-| WSTG-CLIENT-005 | Testing for CSS Injection |
-| WSTG-CLIENT-006 | Testing for Client Side Resource Manipulation |
-| WSTG-CLIENT-007 | Test Cross Origin Resource Sharing |
-| WSTG-CLIENT-008 | Testing for Cross Site Flashing |
-| WSTG-CLIENT-009 | Testing for Clickjacking |
-| WSTG-CLIENT-010 | Testing WebSockets |
-| WSTG-CLIENT-011 | Test Web Messaging |
-| WSTG-CLIENT-012 | Test Local Storage |
+| WSTG-CLNT-01 | Testing for DOM based Cross Site Scripting |
+| WSTG-CLNT-02 | Testing for JavaScript Execution |
+| WSTG-CLNT-03 | Testing for HTML Injection |
+| WSTG-CLNT-04 | Testing for Client Side URL Redirect |
+| WSTG-CLNT-05 | Testing for CSS Injection |
+| WSTG-CLNT-06 | Testing for Client Side Resource Manipulation |
+| WSTG-CLNT-07 | Test Cross Origin Resource Sharing |
+| WSTG-CLNT-08 | Testing for Cross Site Flashing |
+| WSTG-CLNT-09 | Testing for Clickjacking |
+| WSTG-CLNT-10 | Testing WebSockets |
+| WSTG-CLNT-11 | Test Web Messaging |
+| WSTG-CLNT-12 | Test Local Storage |
 
 ## Appendix
 

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -130,8 +130,8 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-INPV-16  | Testing for HTTP Splitting/Smuggling |
 | WSTG-INPV-17  | Testing for HTTP Incoming requests |
 | **WSTG-ERR**  |**Error Handling** |
-| WSTG-ERR-001  | Analysis of Error Codes |
-| WSTG-ERR-002  | Analysis of Stack Traces |
+| WSTG-ERRH-01  | Analysis of Error Codes |
+| WSTG-ERRH-02  | Analysis of Stack Traces |
 | **WSTG-CRYPST** | **Cryptography** |
 | WSTG-CRYPST-001 | Testing for Weak SSL/TSL Ciphers, Insufficient|
 | **WSTG-CRYPST** | **Transport Layer Protection** |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -68,13 +68,13 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-CONF-07 | Test HTTP Strict Transport Security |
 | WSTG-CONF-08 | Test RIA cross domain policy |
 | **WSTG-IDENT** | **Identity Management Testing** |
-| WSTG-IDENT-001 | Test Role Definitions |
-| WSTG-IDENT-002 | Test User Registration Process |
-| WSTG-IDENT-003 | Test Account Provisioning Process |
-| WSTG-IDENT-004 | Testing for Account Enumeration and Guessable User Account |
-| WSTG-IDENT-005 | Testing for Weak or unenforced username policy |
-| WSTG-IDENT-006 | Test Permissions of Guest/Training Accounts |
-| WSTG-IDENT-007 | Test Account Suspension/Resumption Process |
+| WSTG-IDNT-01 | Test Role Definitions |
+| WSTG-IDNT-02 | Test User Registration Process |
+| WSTG-IDNT-03 | Test Account Provisioning Process |
+| WSTG-IDNT-04 | Testing for Account Enumeration and Guessable User Account |
+| WSTG-IDNT-05 | Testing for Weak or unenforced username policy |
+| WSTG-IDNT-06 | Test Permissions of Guest/Training Accounts |
+| WSTG-IDNT-07 | Test Account Suspension/Resumption Process |
 | **WSTG-AUTHN** | **Authentication Testing** |
 | WSTG-AUTHN-001 | Testing for Credentials Transported over an Encrypted Channel |
 | WSTG-AUTHN-002 | Testing for default credentials |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -92,14 +92,14 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-ATHZ-03 | Testing for Privilege Escalation |
 | WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
 | **WSTG-SESS** | **Session Management Testing** |
-| WSTG-SESS-001 | Testing for Bypassing Session Management Schema |
-| WSTG-SESS-002 | Testing for Cookies attributes |
-| WSTG-SESS-003 | Testing for Session Fixation |
-| WSTG-SESS-004 | Testing for Exposed Session Variables |
-| WSTG-SESS-005 | Testing for Cross Site Request Forgery |
-| WSTG-SESS-006 | Testing for logout functionality |
-| WSTG-SESS-007 | Test Session Timeout |
-| WSTG-SESS-008 | Testing for Session puzzling |
+| WSTG-SESS-01 | Testing for Bypassing Session Management Schema |
+| WSTG-SESS-02 | Testing for Cookies attributes |
+| WSTG-SESS-03 | Testing for Session Fixation |
+| WSTG-SESS-04 | Testing for Exposed Session Variables |
+| WSTG-SESS-05 | Testing for Cross Site Request Forgery |
+| WSTG-SESS-06 | Testing for logout functionality |
+| WSTG-SESS-07 | Test Session Timeout |
+| WSTG-SESS-08 | Testing for Session puzzling |
 | **WSTG-INPVAL** |**Input Validation Testing** |
 | WSTG-INPVAL-001 | Testing for Reflected Cross Site Scripting |
 | WSTG-INPVAL-002 | Testing for Stored Cross Site Scripting |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -87,10 +87,10 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-ATHN-09 | Testing for weak password change or reset functionalities |
 | WSTG-ATHN-10 | Testing for Weaker authentication in alternative channel |
 | **WSTG-AUTHZ** | **Authorization Testing** |
-| WSTG-AUTHZ-001 | Testing Directory traversal/file include |
-| WSTG-AUTHZ-002 | Testing for bypassing authorization schema |
-| WSTG-AUTHZ-003 | Testing for Privilege Escalation |
-| WSTG-AUTHZ-004 | Testing for Insecure Direct Object References |
+| WSTG-ATHZ-01 | Testing Directory traversal/file include |
+| WSTG-ATHZ-02 | Testing for bypassing authorization schema |
+| WSTG-ATHZ-03 | Testing for Privilege Escalation |
+| WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
 | **WSTG-SESS** | **Session Management Testing** |
 | WSTG-SESS-001 | Testing for Bypassing Session Management Schema |
 | WSTG-SESS-002 | Testing for Cookies attributes |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -59,7 +59,7 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-INFO-09 | Fingerprint Web Application |
 | WSTG-INFO-10 | Map Application Architecture |
 | **WSTG-CONF** | **Configuration and Deploy Management Testing** |
-| WSTG-CONF-01 | Test Network/Infrastructure Configuration |
+| WSTG-CONF-01 | Test Network Infrastructure Configuration |
 | WSTG-CONF-02 | Test Application Platform Configuration |
 | WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
 | WSTG-CONF-04 | Backup and Unreferenced Files for Sensitive Information |
@@ -67,20 +67,21 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-CONF-06 | Test HTTP Methods |
 | WSTG-CONF-07 | Test HTTP Strict Transport Security |
 | WSTG-CONF-08 | Test RIA Cross Domain Policy |
+| WSTG-CONF-09 | Test File Permission |
+| WSTG-CONF-10 | Test for Subdomain Takeover |
+| WSTG-CONF-11 | Test Cloud Storage |
 | **WSTG-IDNT** | **Identity Management Testing** |
 | WSTG-IDNT-01 | Test Role Definitions |
 | WSTG-IDNT-02 | Test User Registration Process |
 | WSTG-IDNT-03 | Test Account Provisioning Process |
 | WSTG-IDNT-04 | Testing for Account Enumeration and Guessable User Account |
 | WSTG-IDNT-05 | Testing for Weak or Unenforced Username Policy |
-| WSTG-IDNT-06 | Test Permissions of Guest/Training Accounts |
-| WSTG-IDNT-07 | Test Account Suspension/Resumption Process |
 | **WSTG-ATHN** | **Authentication Testing** |
 | WSTG-ATHN-01 | Testing for Credentials Transported over an Encrypted Channel |
-| WSTG-ATHN-02 | Testing for default credentials |
+| WSTG-ATHN-02 | Testing for Default Credentials |
 | WSTG-ATHN-03 | Testing for Weak Lock Out Mechanism |
 | WSTG-ATHN-04 | Testing for Bypassing Authentication Schema |
-| WSTG-ATHN-05 | Test Remember Password Functionality |
+| WSTG-ATHN-05 | Testing for Vulnerable Remember Password |
 | WSTG-ATHN-06 | Testing for Browser Cache Weakness |
 | WSTG-ATHN-07 | Testing for Weak Password Policy |
 | WSTG-ATHN-08 | Testing for Weak Security Question Answer |
@@ -106,14 +107,14 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-INPV-03 | Testing for HTTP Verb Tampering |
 | WSTG-INPV-04 | Testing for HTTP Parameter pollution |
 | WSTG-INPV-05 | Testing for SQL Injection |
-| | Oracle Testing |
-| | MySQL Testing   |
-| | SQL Server Testing |
-| | Testing PostgreSQL |
-| | MS Access Testing |
-| | Testing for NoSQL injection |
-| | Testing for ORM Injection |
-| | Testing for Client Side |
+| | Oracle |
+| | MySQL |
+| | SQL Server |
+| | PostgreSQL |
+| | MS Access |
+| | NoSQL |
+| | ORM |
+| | Client Side |
 | WSTG-INPV-06 | Testing for LDAP Injection |
 | WSTG-INPV-07 | Testing for XML Injection |
 | WSTG-INPV-08 | Testing for SSI Injection |
@@ -147,7 +148,7 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-BUSL-04 | Test for Process Timing |
 | WSTG-BUSL-05 | Test Number of Times a Function Can be Used Limits |
 | WSTG-BUSL-06 | Testing for the Circumvention of Work Flows |
-| WSTG-BUSL-07 | Test Defenses Against Application Mis-use |
+| WSTG-BUSL-07 | Test Defenses Against Application Misuse |
 | WSTG-BUSL-08 | Test Upload of Unexpected File Types |
 | WSTG-BUSL-09 | Test Upload of Malicious Files |
 | **WSTG-CLIENT** | **Client Side Testing** |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -101,34 +101,34 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-SESS-07 | Test Session Timeout |
 | WSTG-SESS-08 | Testing for Session puzzling |
 | **WSTG-INPVAL** |**Input Validation Testing** |
-| WSTG-INPVAL-001 | Testing for Reflected Cross Site Scripting |
-| WSTG-INPVAL-002 | Testing for Stored Cross Site Scripting |
-| WSTG-INPVAL-003 | Testing for HTTP Verb Tampering |
-| WSTG-INPVAL-004 | Testing for HTTP Parameter pollution |
-| WSTG-INPVAL-005 | Testing for SQL Injection |
+| WSTG-INPV-01 | Testing for Reflected Cross Site Scripting |
+| WSTG-INPV-02 | Testing for Stored Cross Site Scripting |
+| WSTG-INPV-03 | Testing for HTTP Verb Tampering |
+| WSTG-INPV-04 | Testing for HTTP Parameter pollution |
+| WSTG-INPV-05 | Testing for SQL Injection |
 | | Oracle Testing |
 | | MySQL Testing   |
 | | SQL Server Testing |
 | | Testing PostgreSQL |
 | | MS Access Testing |
 | | Testing for NoSQL injection |
-| WSTG-INPVAL-006 | Testing for LDAP Injection |
-| WSTG-INPVAL-007 | Testing for ORM Injection |
-| WSTG-INPVAL-008 | Testing for XML Injection |
-| WSTG-INPVAL-008 | Testing for SSI Injection |
-| WSTG-INPVAL-010 | Testing for XPath Injection |
-| WSTG-INPVAL-011 | IMAP/SMTP Injection |
-| WSTG-INPVAL-012 |Testing for Code Injection |
+| WSTG-INPV-06 | Testing for LDAP Injection |
+| WSTG-INPV-07 | Testing for ORM Injection |
+| WSTG-INPV-08 | Testing for XML Injection |
+| WSTG-INPV-08 | Testing for SSI Injection |
+| WSTG-INPV-10 | Testing for XPath Injection |
+| WSTG-INPV-11 | IMAP/SMTP Injection |
+| WSTG-INPV-12 |Testing for Code Injection |
 | |Testing for Local File Inclusion |
 | |Testing for Remote File Inclusion |
-| WSTG-INPVAL-013 | Testing for Command Injection |
-| WSTG-INPVAL-014 | Testing for Buffer overflow |
+| WSTG-INPV-13 | Testing for Command Injection |
+| WSTG-INPV-14 | Testing for Buffer overflow |
 | | Testing for Heap overflow |
 | | Testing for Stack overflow |
 | | Testing for Format string |
-| WSTG-INPVAL-015  | Testing for incubated vulnerabilities |
-| WSTG-INPVAL-016  | Testing for HTTP Splitting/Smuggling |
-| WSTG-INPVAL-017  | Testing for HTTP Incoming requests |
+| WSTG-INPV-15  | Testing for incubated vulnerabilities |
+| WSTG-INPV-16  | Testing for HTTP Splitting/Smuggling |
+| WSTG-INPV-17  | Testing for HTTP Incoming requests |
 | **WSTG-ERR**  |**Error Handling** |
 | WSTG-ERR-001  | Analysis of Error Codes |
 | WSTG-ERR-002  | Analysis of Stack Traces |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -138,15 +138,15 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-CRYP-02 | Testing for Padding Oracle |
 | WSTG-CRYP-03 | Testing for Sensitive information sent via unencrypted  channels |
 | **WSTG-BUSLOGIC** | **Business Logic Testing** |
-| WSTG-BUSLOGIC-001 | Test Business Logic Data Validation |
-| WSTG-BUSLOGIC-002 | Test Ability to Forge Requests |
-| WSTG-BUSLOGIC-003 | Test Integrity Checks |
-| WSTG-BUSLOGIC-004 | Test for Process Timing |
-| WSTG-BUSLOGIC-005 | Test Number of Times a Function Can be Used Limits |
-| WSTG-BUSLOGIC-006 | Testing for the Circumvention of Work Flows |
-| WSTG-BUSLOGIC-007 | Test Defenses Against Application Mis-use |
-| WSTG-BUSLOGIC-008 | Test Upload of Unexpected File Types |
-| WSTG-BUSLOGIC-009 | Test Upload of Malicious Files |
+| WSTG-BUSL-01 | Test Business Logic Data Validation |
+| WSTG-BUSL-02 | Test Ability to Forge Requests |
+| WSTG-BUSL-03 | Test Integrity Checks |
+| WSTG-BUSL-04 | Test for Process Timing |
+| WSTG-BUSL-05 | Test Number of Times a Function Can be Used Limits |
+| WSTG-BUSL-06 | Testing for the Circumvention of Work Flows |
+| WSTG-BUSL-07 | Test Defenses Against Application Mis-use |
+| WSTG-BUSL-08 | Test Upload of Unexpected File Types |
+| WSTG-BUSL-09 | Test Upload of Malicious Files |
 | **WSTG-CLIENT** | **Client Side Testing** |
 | WSTG-CLIENT-001 | Testing for DOM based Cross Site Scripting |
 | WSTG-CLIENT-002 | Testing for JavaScript Execution |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -59,14 +59,14 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-INFO-09 | Fingerprint Web Application |
 | WSTG-INFO-10 | Map Application Architecture |
 | **WSTG-CONFIG** | **Configuration and Deploy Management Testing** |
-| WSTG-CONFIG-001 | Test Network/Infrastructure Configuration |
-| WSTG-CONFIG-002 | Test Application Platform Configuration |
-| WSTG-CONFIG-003 | Test File Extensions Handling for Sensitive Information |
-| WSTG-CONFIG-004 | Backup and Unreferenced Files for Sensitive Information |
-| WSTG-CONFIG-005 | Enumerate Infrastructure and Application Admin Interfaces |
-| WSTG-CONFIG-006 | Test HTTP Methods |
-| WSTG-CONFIG-007 | Test HTTP Strict Transport Security |
-| WSTG-CONFIG-008 | Test RIA cross domain policy |
+| WSTG-CONF-01 | Test Network/Infrastructure Configuration |
+| WSTG-CONF-02 | Test Application Platform Configuration |
+| WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
+| WSTG-CONF-04 | Backup and Unreferenced Files for Sensitive Information |
+| WSTG-CONF-05 | Enumerate Infrastructure and Application Admin Interfaces |
+| WSTG-CONF-06 | Test HTTP Methods |
+| WSTG-CONF-07 | Test HTTP Strict Transport Security |
+| WSTG-CONF-08 | Test RIA cross domain policy |
 | **WSTG-IDENT** | **Identity Management Testing** |
 | WSTG-IDENT-001 | Test Role Definitions |
 | WSTG-IDENT-002 | Test User Registration Process |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -48,16 +48,16 @@ The following is the list of controls that were tested during the assessment:
 | Test ID  | Test Description | Findings | Severity | Recommendations |
 | ---------| -----------------| -------- | -------- | --------------- |
 | **WSTG-INFO**     | **Information Gathering**  |
-| WSTG-INFO-001 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
-| WSTG-INFO-002 | Fingerprint Web Server |
-| WSTG-INFO-003 | Review Webserver Metafiles for Information |
-| WSTG-INFO-004 | Enumerate Applications on Webserver |
-| WSTG-INFO-005 | Review Webpage Comments and Metadata for Information Leakage |
-| WSTG-INFO-006 | Identify application entry points |
-| WSTG-INFO-007 | Map execution paths through application |
-| WSTG-INFO-009 | Fingerprint Web Application Framework |
-| WSTG-INFO-009 | Fingerprint Web Application |
-| WSTG-INFO-010 | Map Application Architecture |
+| WSTG-INFO-01 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
+| WSTG-INFO-02 | Fingerprint Web Server |
+| WSTG-INFO-03 | Review Webserver Metafiles for Information |
+| WSTG-INFO-04 | Enumerate Applications on Webserver |
+| WSTG-INFO-05 | Review Webpage Comments and Metadata for Information Leakage |
+| WSTG-INFO-06 | Identify application entry points |
+| WSTG-INFO-07 | Map execution paths through application |
+| WSTG-INFO-09 | Fingerprint Web Application Framework |
+| WSTG-INFO-09 | Fingerprint Web Application |
+| WSTG-INFO-10 | Map Application Architecture |
 | **WSTG-CONFIG** | **Configuration and Deploy Management Testing** |
 | WSTG-CONFIG-001 | Test Network/Infrastructure Configuration |
 | WSTG-CONFIG-002 | Test Application Platform Configuration |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -76,16 +76,16 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-IDNT-06 | Test Permissions of Guest/Training Accounts |
 | WSTG-IDNT-07 | Test Account Suspension/Resumption Process |
 | **WSTG-AUTHN** | **Authentication Testing** |
-| WSTG-AUTHN-001 | Testing for Credentials Transported over an Encrypted Channel |
-| WSTG-AUTHN-002 | Testing for default credentials |
-| WSTG-AUTHN-003 | Testing for Weak lock out mechanism |
-| WSTG-AUTHN-004 | Testing for bypassing authentication schema |
-| WSTG-AUTHN-005 | Test remember password functionality |
-| WSTG-AUTHN-006 | Testing for Browser cache weakness |
-| WSTG-AUTHN-007 | Testing for Weak password policy |
-| WSTG-AUTHN-008 | Testing for Weak security question/answer |
-| WSTG-AUTHN-009 | Testing for weak password change or reset functionalities |
-| WSTG-AUTHN-010 | Testing for Weaker authentication in alternative channel |
+| WSTG-ATHN-01 | Testing for Credentials Transported over an Encrypted Channel |
+| WSTG-ATHN-02 | Testing for default credentials |
+| WSTG-ATHN-03 | Testing for Weak lock out mechanism |
+| WSTG-ATHN-04 | Testing for bypassing authentication schema |
+| WSTG-ATHN-05 | Test remember password functionality |
+| WSTG-ATHN-06 | Testing for Browser cache weakness |
+| WSTG-ATHN-07 | Testing for Weak password policy |
+| WSTG-ATHN-08 | Testing for Weak security question/answer |
+| WSTG-ATHN-09 | Testing for weak password change or reset functionalities |
+| WSTG-ATHN-10 | Testing for Weaker authentication in alternative channel |
 | **WSTG-AUTHZ** | **Authorization Testing** |
 | WSTG-AUTHZ-001 | Testing Directory traversal/file include |
 | WSTG-AUTHZ-002 | Testing for bypassing authorization schema |

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -47,18 +47,18 @@ The following is the list of controls that were tested during the assessment:
 
 | Test ID  | Test Description | Findings | Severity | Recommendations |
 | ---------| -----------------| -------- | -------- | --------------- |
-| **WSTG-INFO**     | **Information Gathering**  |
+| **WSTG-INFO** | **Information Gathering** |
 | WSTG-INFO-01 | Conduct Search Engine Discovery and Reconnaissance for Information Leakage |
 | WSTG-INFO-02 | Fingerprint Web Server |
 | WSTG-INFO-03 | Review Webserver Metafiles for Information |
 | WSTG-INFO-04 | Enumerate Applications on Webserver |
 | WSTG-INFO-05 | Review Webpage Comments and Metadata for Information Leakage |
-| WSTG-INFO-06 | Identify application entry points |
-| WSTG-INFO-07 | Map execution paths through application |
+| WSTG-INFO-06 | Identify Application Entry Points |
+| WSTG-INFO-07 | Map Execution Paths Through Application |
 | WSTG-INFO-09 | Fingerprint Web Application Framework |
 | WSTG-INFO-09 | Fingerprint Web Application |
 | WSTG-INFO-10 | Map Application Architecture |
-| **WSTG-CONFIG** | **Configuration and Deploy Management Testing** |
+| **WSTG-CONF** | **Configuration and Deploy Management Testing** |
 | WSTG-CONF-01 | Test Network/Infrastructure Configuration |
 | WSTG-CONF-02 | Test Application Platform Configuration |
 | WSTG-CONF-03 | Test File Extensions Handling for Sensitive Information |
@@ -66,41 +66,41 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-CONF-05 | Enumerate Infrastructure and Application Admin Interfaces |
 | WSTG-CONF-06 | Test HTTP Methods |
 | WSTG-CONF-07 | Test HTTP Strict Transport Security |
-| WSTG-CONF-08 | Test RIA cross domain policy |
-| **WSTG-IDENT** | **Identity Management Testing** |
+| WSTG-CONF-08 | Test RIA Cross Domain Policy |
+| **WSTG-IDNT** | **Identity Management Testing** |
 | WSTG-IDNT-01 | Test Role Definitions |
 | WSTG-IDNT-02 | Test User Registration Process |
 | WSTG-IDNT-03 | Test Account Provisioning Process |
 | WSTG-IDNT-04 | Testing for Account Enumeration and Guessable User Account |
-| WSTG-IDNT-05 | Testing for Weak or unenforced username policy |
+| WSTG-IDNT-05 | Testing for Weak or Unenforced Username Policy |
 | WSTG-IDNT-06 | Test Permissions of Guest/Training Accounts |
 | WSTG-IDNT-07 | Test Account Suspension/Resumption Process |
-| **WSTG-AUTHN** | **Authentication Testing** |
+| **WSTG-ATHN** | **Authentication Testing** |
 | WSTG-ATHN-01 | Testing for Credentials Transported over an Encrypted Channel |
 | WSTG-ATHN-02 | Testing for default credentials |
-| WSTG-ATHN-03 | Testing for Weak lock out mechanism |
-| WSTG-ATHN-04 | Testing for bypassing authentication schema |
-| WSTG-ATHN-05 | Test remember password functionality |
-| WSTG-ATHN-06 | Testing for Browser cache weakness |
-| WSTG-ATHN-07 | Testing for Weak password policy |
-| WSTG-ATHN-08 | Testing for Weak security question/answer |
-| WSTG-ATHN-09 | Testing for weak password change or reset functionalities |
-| WSTG-ATHN-10 | Testing for Weaker authentication in alternative channel |
-| **WSTG-AUTHZ** | **Authorization Testing** |
-| WSTG-ATHZ-01 | Testing Directory traversal/file include |
-| WSTG-ATHZ-02 | Testing for bypassing authorization schema |
+| WSTG-ATHN-03 | Testing for Weak Lock Out Mechanism |
+| WSTG-ATHN-04 | Testing for Bypassing Authentication Schema |
+| WSTG-ATHN-05 | Test Remember Password Functionality |
+| WSTG-ATHN-06 | Testing for Browser Cache Weakness |
+| WSTG-ATHN-07 | Testing for Weak Password Policy |
+| WSTG-ATHN-08 | Testing for Weak Security Question Answer |
+| WSTG-ATHN-09 | Testing for Weak Password Change or Reset Functionalities |
+| WSTG-ATHN-10 | Testing for Weaker Authentication in Alternative Channel |
+| **WSTG-ATHZ** | **Authorization Testing** |
+| WSTG-ATHZ-01 | Testing Directory Traversal - File Include |
+| WSTG-ATHZ-02 | Testing for Bypassing Authorization Schema |
 | WSTG-ATHZ-03 | Testing for Privilege Escalation |
 | WSTG-ATHZ-04 | Testing for Insecure Direct Object References |
 | **WSTG-SESS** | **Session Management Testing** |
 | WSTG-SESS-01 | Testing for Bypassing Session Management Schema |
-| WSTG-SESS-02 | Testing for Cookies attributes |
+| WSTG-SESS-02 | Testing for Cookies Attributes |
 | WSTG-SESS-03 | Testing for Session Fixation |
 | WSTG-SESS-04 | Testing for Exposed Session Variables |
 | WSTG-SESS-05 | Testing for Cross Site Request Forgery |
-| WSTG-SESS-06 | Testing for logout functionality |
+| WSTG-SESS-06 | Testing for Logout Functionality |
 | WSTG-SESS-07 | Test Session Timeout |
-| WSTG-SESS-08 | Testing for Session puzzling |
-| **WSTG-INPVAL** |**Input Validation Testing** |
+| WSTG-SESS-08 | Testing for Session Puzzling |
+| **WSTG-INPV** |**Input Validation Testing** |
 | WSTG-INPV-01 | Testing for Reflected Cross Site Scripting |
 | WSTG-INPV-02 | Testing for Stored Cross Site Scripting |
 | WSTG-INPV-03 | Testing for HTTP Verb Tampering |
@@ -112,31 +112,34 @@ The following is the list of controls that were tested during the assessment:
 | | Testing PostgreSQL |
 | | MS Access Testing |
 | | Testing for NoSQL injection |
+| | Testing for ORM Injection |
+| | Testing for Client Side |
 | WSTG-INPV-06 | Testing for LDAP Injection |
-| WSTG-INPV-07 | Testing for ORM Injection |
-| WSTG-INPV-08 | Testing for XML Injection |
+| WSTG-INPV-07 | Testing for XML Injection |
 | WSTG-INPV-08 | Testing for SSI Injection |
-| WSTG-INPV-10 | Testing for XPath Injection |
-| WSTG-INPV-11 | IMAP/SMTP Injection |
-| WSTG-INPV-12 |Testing for Code Injection |
+| WSTG-INPV-09 | Testing for XPath Injection |
+| WSTG-INPV-10 | IMAP/SMTP Injection |
+| WSTG-INPV-11 | Testing for Code Injection |
 | |Testing for Local File Inclusion |
 | |Testing for Remote File Inclusion |
-| WSTG-INPV-13 | Testing for Command Injection |
-| WSTG-INPV-14 | Testing for Buffer overflow |
-| | Testing for Heap overflow |
-| | Testing for Stack overflow |
-| | Testing for Format string |
-| WSTG-INPV-15  | Testing for incubated vulnerabilities |
-| WSTG-INPV-16  | Testing for HTTP Splitting/Smuggling |
-| WSTG-INPV-17  | Testing for HTTP Incoming requests |
-| **WSTG-ERR**  |**Error Handling** |
+| WSTG-INPV-12 | Testing for Command Injection |
+| WSTG-INPV-13 | Testing for Buffer overflow |
+| | Testing for Heap Overflow |
+| | Testing for Stack Overflow |
+| | Testing for Format String |
+| WSTG-INPV-14 | Testing for Incubated Vulnerabilities |
+| WSTG-INPV-15 | Testing for HTTP Splitting/Smuggling |
+| WSTG-INPV-16 | Testing for HTTP Incoming Requests |
+| WSTG-INPV-17 | Testing for Host Header Injection |
+| WSTG-INPV-18 | Testing for Server Side Template Injection |
+| **WSTG-ERRH**  |**Error Handling** |
 | WSTG-ERRH-01  | Analysis of Error Codes |
 | WSTG-ERRH-02  | Analysis of Stack Traces |
-| **WSTG-CRYPST** | **Cryptography** |
-| WSTG-CRYP-01 | Testing for Weak SSL/TSL Ciphers, Insufficient|
-| **WSTG-CRYPST** | **Transport Layer Protection** |
+| **WSTG-CRYP** | **Cryptography** |
+| WSTG-CRYP-01 | Testing for Weak Cryptography |
 | WSTG-CRYP-02 | Testing for Padding Oracle |
-| WSTG-CRYP-03 | Testing for Sensitive information sent via unencrypted  channels |
+| WSTG-CRYP-03 | Testing for Sensitive Information Sent Via Unencrypted Channels |
+| WSTG-CRYP-04 | Testing for Weak Encryption |
 | **WSTG-BUSLOGIC** | **Business Logic Testing** |
 | WSTG-BUSL-01 | Test Business Logic Data Validation |
 | WSTG-BUSL-02 | Test Ability to Forge Requests |
@@ -160,6 +163,7 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-CLNT-10 | Testing WebSockets |
 | WSTG-CLNT-11 | Test Web Messaging |
 | WSTG-CLNT-12 | Test Local Storage |
+| WSTG-CLNT-13 | Testing for Cross Site Script Inclusion |
 
 ## Appendix
 

--- a/document/5-Reporting/README.md
+++ b/document/5-Reporting/README.md
@@ -133,10 +133,10 @@ The following is the list of controls that were tested during the assessment:
 | WSTG-ERRH-01  | Analysis of Error Codes |
 | WSTG-ERRH-02  | Analysis of Stack Traces |
 | **WSTG-CRYPST** | **Cryptography** |
-| WSTG-CRYPST-001 | Testing for Weak SSL/TSL Ciphers, Insufficient|
+| WSTG-CRYP-01 | Testing for Weak SSL/TSL Ciphers, Insufficient|
 | **WSTG-CRYPST** | **Transport Layer Protection** |
-| WSTG-CRYPST-002 | Testing for Padding Oracle |
-| WSTG-CRYPST-003 | Testing for Sensitive information sent via unencrypted  channels |
+| WSTG-CRYP-02 | Testing for Padding Oracle |
+| WSTG-CRYP-03 | Testing for Sensitive information sent via unencrypted  channels |
 | **WSTG-BUSLOGIC** | **Business Logic Testing** |
 | WSTG-BUSLOGIC-001 | Test Business Logic Data Validation |
 | WSTG-BUSLOGIC-002 | Test Ability to Forge Requests |


### PR DESCRIPTION
**What did this PR accomplish?**
- Rename the group identifiers to follow a 4 letter convention:
1. WSTG-INFO-01
1. WSTG-CONF-01
1. WSTG-IDNT-01
1. WSTG-ATHN-01
1. WSTG-ATHZ-01
1. WSTG-SESS-01
1. WSTG-INPV-01
1. WSTG-ERRH-01
1. WSTG-CRYP-01
1. WSTG-BUSL-01
1. WSTG-CLNT-01
- Remove the 3rd `0` in the identifiers
- Update the whole guide accordingly