### PR TITLE
Switch to checkout v2 and totally ignore `www` dir

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -14,7 +14,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/md-lint-check.yml
+++ b/.github/workflows/md-lint-check.yml
@@ -14,7 +14,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/www_latest_update.yml
+++ b/.github/workflows/www_latest_update.yml
@@ -34,7 +34,7 @@ jobs:
         echo ::set-env name=SRC_BASE="OWASP/wstg@"$(git log -1 --format=format:%h)
         echo ::set-env name=BRANCH_STAMP="$(date +"%Y%m%d%H%M%S")"
         echo ::set-env name=SHORT_DATE="$(date +"%Y-%m-%d")"
-        cd ../www-project-web-security-test-guide
+        cd ../www-project-web-security-testing-guide
         echo ::set-env name=WWW_BASE::"$(pwd)"
     - name: Create Feature Branch
       run: |

--- a/.github/workflows/www_latest_update.yml
+++ b/.github/workflows/www_latest_update.yml
@@ -71,7 +71,7 @@ jobs:
         sed -i 's/.md/.html/g' README.md
         # Add the leadin and add the generated yaml
         cat prepend.nav > latest.yaml && cat README.md >> latest.yaml
-        # Create the _data directory if necessary and copy the navigation yaml to it
+        # Copy the navigation yaml to _data
         cp latest.yaml $WWW_BASE/_data/.
     - name: Push Feature Branch and Raise PR
       run: |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "markdownlint-cli": "^0.19.0"
   },
   "scripts": {
-    "test": "markdownlint .  --ignore node_modules"
+    "test": "markdownlint .  --ignore node_modules --ignore www"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Per https://github.com/actions/checkout/issues/23#issuecomment-572688577 this should address re-run failures.
- Not only should the action ignore `www` (as was [done earlier](https://github.com/OWASP/wstg/pull/405)) but when it does run markdownlint should ignore `www` to prevent failures such as: https://github.com/OWASP/wstg/runs/568366043?check_suite_focus=true


Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>