### PR TITLE
Create README for Section 3

### DIFF
--- a/document/3-The_OWASP_Testing_Framework/README.md
+++ b/document/3-The_OWASP_Testing_Framework/README.md
@@ -1,0 +1,17 @@
+# The OWASP Testing Framework
+
+[3.1 Overview](0-The_OWASP_Testing_Framework.md#Overview)
+
+[3.2 Phase 1: Before Development Begins](0-The_OWASP_Testing_Framework.md#Phase-1-Before-Development-Begins)
+
+[3.3 Phase 2: During Definition and Design](0-The_OWASP_Testing_Framework.md#Phase-2-During-Definition-and-Design)
+
+[3.4 Phase 3: During Development](0-The_OWASP_Testing_Framework.md#Phase-3-During-Development)
+
+[3.5 Phase 4: During Deployment](0-The_OWASP_Testing_Framework.md#Phase-4-During-Deployment)
+
+[3.6 Phase 5: During Maintenance and Operations](0-The_OWASP_Testing_Framework.md#Phase-5-During-Maintenance-and-Operations)
+
+[3.7 A Typical SDLC Testing Workflow](0-The_OWASP_Testing_Framework.md#A-Typical-SDLC-Testing-Workflow)
+
+[3.8 Penetration Testing Methodologies](1-Penetration_Testing_Methodologies.md)

--- a/document/3-The_OWASP_Testing_Framework/README.md
+++ b/document/3-The_OWASP_Testing_Framework/README.md
@@ -1,17 +1,17 @@
 # The OWASP Testing Framework
 
-[3.1 Overview](0-The_OWASP_Testing_Framework.md#Overview)
+3.1 [Overview](0-The_OWASP_Testing_Framework.md#Overview)
 
-[3.2 Phase 1: Before Development Begins](0-The_OWASP_Testing_Framework.md#Phase-1-Before-Development-Begins)
+3.2 [Phase 1: Before Development Begins](0-The_OWASP_Testing_Framework.md#Phase-1-Before-Development-Begins)
 
-[3.3 Phase 2: During Definition and Design](0-The_OWASP_Testing_Framework.md#Phase-2-During-Definition-and-Design)
+3.3 [Phase 2: During Definition and Design](0-The_OWASP_Testing_Framework.md#Phase-2-During-Definition-and-Design)
 
-[3.4 Phase 3: During Development](0-The_OWASP_Testing_Framework.md#Phase-3-During-Development)
+3.4 [Phase 3: During Development](0-The_OWASP_Testing_Framework.md#Phase-3-During-Development)
 
-[3.5 Phase 4: During Deployment](0-The_OWASP_Testing_Framework.md#Phase-4-During-Deployment)
+3.5 [Phase 4: During Deployment](0-The_OWASP_Testing_Framework.md#Phase-4-During-Deployment)
 
-[3.6 Phase 5: During Maintenance and Operations](0-The_OWASP_Testing_Framework.md#Phase-5-During-Maintenance-and-Operations)
+3.6 [Phase 5: During Maintenance and Operations](0-The_OWASP_Testing_Framework.md#Phase-5-During-Maintenance-and-Operations)
 
-[3.7 A Typical SDLC Testing Workflow](0-The_OWASP_Testing_Framework.md#A-Typical-SDLC-Testing-Workflow)
+3.7 [A Typical SDLC Testing Workflow](0-The_OWASP_Testing_Framework.md#A-Typical-SDLC-Testing-Workflow)
 
-[3.8 Penetration Testing Methodologies](1-Penetration_Testing_Methodologies.md)
+3.8 [Penetration Testing Methodologies](1-Penetration_Testing_Methodologies.md)

--- a/document/README.md
+++ b/document/README.md
@@ -32,15 +32,15 @@
 
 ### [3.1 Overview](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Overview)
 
-### [3.2 Phase 1: Before Development Begins](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-1:-Before-Development-Begins)
+### [3.2 Phase 1: Before Development Begins](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-1-Before-Development-Begins)
 
-### [3.3 Phase 2: During Definition and Design](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-2:-During-Definition-and-Design)
+### [3.3 Phase 2: During Definition and Design](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-2-During-Definition-and-Design)
 
-### [3.4 Phase 3: During Development](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-3:-During-Development)
+### [3.4 Phase 3: During Development](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-3-During-Development)
 
-### [3.5 Phase 4: During Deployment](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-4:-During-Deployment)
+### [3.5 Phase 4: During Deployment](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-4-During-Deployment)
 
-### [3.6 Phase 5: During Maintenance and Operations](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-5:-During-Maintenance-and-Operations)
+### [3.6 Phase 5: During Maintenance and Operations](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-5-During-Maintenance-and-Operations)
 
 ### [3.7 A Typical SDLC Testing Workflow](3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#A-Typical-SDLC-Testing-Workflow)
 


### PR DESCRIPTION
- Added README.md in side chapter 3.
- Trimmed colons from anchors in both the new README.md in chapter 3 and the base README. They don't seem to be accepted on either github or the www site.
  - Ex GitHub:
https://github.com/OWASP/wstg/blob/master/document/3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-2:-During-Definition-and-Design
vs https://github.com/OWASP/wstg/blob/master/document/3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.md#Phase-2-During-Definition-and-Design
  - Ex www: https://owasp.org/www-project-web-security-testing-guide/latest/3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.html#phase-2:-during-definition-and-design
vs
https://owasp.org/www-project-web-security-testing-guide/latest/3-The_OWASP_Testing_Framework/0-The_OWASP_Testing_Framework.html#phase-2-during-definition-and-design

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>