### PR TITLE
Add Stable and Versioned Publishing Job

### DIFF
--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -1,4 +1,4 @@
-name: Deploy Latest WSTG Content to Web
+name: Deploy Stable and Versioned WSTG Content to Web
 
 on:
   push:

--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Create Feature Branch
       run: |
         cd $WSTG_BASE
-        git checkout tags/$VERSION -b ver-branch
+        git checkout tags/$VERS_TAG -b ver-branch
         cd $WWW_BASE
         git remote add origin https://github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         # Checkout what will be the new feature branch

--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -1,0 +1,129 @@
+name: Deploy Latest WSTG Content to Web
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create_pr:
+    name: Create Pull Request
+    if: github.actor == 'kingthorin' || github.actor == 'ThunderSon' || github.actor == 'rejahrehim' || github.actor == 'victoriadrake'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup
+      run: |
+        sudo apt update
+        sudo apt install moreutils
+        sudo snap install yq
+    - name: Git Clone and Global Config
+      run: |
+        # Git setup
+        export GITHUB_USER=wstgbot
+        echo ::set-env name=GITHUB_USER::$GITHUB_USER
+        echo ::set-env name=GITHUB_TOKEN::${{ secrets.wstg_deploy_token }}
+        git config --global user.email "62450690+wstgbot@users.noreply.github.com"
+        git config --global user.name $GITHUB_USER
+        # Clone the necessary repos
+        git clone https://github.com/OWASP/wstg.git
+        git clone -o upstream https://github.com/OWASP/www-project-web-security-testing-guide.git
+    - name: Setup Environment Variables
+      run : |
+        # Setup some env vars etc for future use
+        # Extract version from tag ref
+        VERS_TAG=${GITHUB_REF/refs\/tags\//}
+        echo ::set-env name=VERS_TAG::$VERS_TAG
+        VERSION=$(echo $VERS | tr -d .)
+        echo ::set-env name=VERSION::$VERSION
+        cd wstg
+        echo ::set-env name=WSTG_BASE::"$(pwd)"
+        echo ::set-env name=SRC_BASE::"OWASP/wstg@"$(git log -1 --format=format:%h)
+        echo ::set-env name=BRANCH_STAMP::"$(date +"%Y%m%d%H%M%S")"
+        echo ::set-env name=SHORT_DATE::"$(date +"%Y-%m-%d")"
+        cd ../www-project-web-security-testing-guide
+        echo ::set-env name=WWW_BASE::"$(pwd)"
+    - name: Create Feature Branch
+      run: |
+        cd $WSTG_BASE
+        git checkout tags/$VERSION -b ver-branch
+        cd $WWW_BASE
+        git remote add origin https://github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
+        # Checkout what will be the new feature branch
+        git checkout -b $BRANCH_STAMP
+        # Remove old 'stable' content
+        rm -rf stable
+        mkdir stable
+        # Copy new 'stable' content
+        cp -R $WSTG_BASE/document/* ./stable
+        # Create version directory
+        mkdir $VERSION
+        # Copy new version content
+        cp -R $WSTG_BASE/document/* ./$VERSION
+    - name: Modify Files for Web Deployment (Stable)
+      run: |
+        cd $WWW_BASE/stable
+        # Append front mater
+        for FILE in `find . -type f -name "*.md"`; do cat $WSTG_BASE/www/stable/prepend.txt $FILE | sponge $FILE; done
+        # Duplicate README.md as index.md in case people forcefully browse to directory bases
+        find . -type f -name "README.md" -execdir cp -v {} ./index.md \;
+        # Copy info.md to all directories (excluding 'images' directories)
+        find . -type d -not -name "images" -execdir cp -v $WSTG_BASE/www/stable/info.md {} \;
+    - name: Setup Navigation (Stable)
+      run: |
+        # Copy the current ToC for manipulation
+        cp $WSTG_BASE/document/README.md $WSTG_BASE/www/stable/.
+        cd $WSTG_BASE/www/stable/
+        # Create new navigation details from ToC
+        # Handle numbered entries
+        sed -i -E 's/^#{2,5}\s([0-9.]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
+        # Handle un-numbered entries
+        sed -i -E 's/^#{2,5}\s\[(.*?)\]\((.*?)\)/- title: '\''\1'\''\n  url: \2/g' README.md
+        # Remove the title from the README (first line)
+        sed -i '1d' README.md
+        # Find the anchor links (URL fragments) and lowercase them
+        sed -i -E 's/\.md#(.*)$/\.md#\L\1/g' README.md
+        # Switch .md references to .html
+        sed -i 's/.md/.html/g' README.md
+        # Add the leadin and add the generated yaml
+        cat prepend.nav > stable.yaml && cat README.md >> stable.yaml
+        # Copy the navigation yaml to _data
+        cp stable.yaml $WWW_BASE/_data/.
+    - name: Modify Files for Web Deployment (Versioned)
+      run: |
+        cd $WWW_BASE/$VERSION
+        # Append front mater
+        for FILE in `find . -type f -name "*.md"`; do cat $WSTG_BASE/www/$VERSION/prepend.txt $FILE | sponge $FILE; done
+        # Duplicate README.md as index.md in case people forcefully browse to directory bases
+        find . -type f -name "README.md" -execdir cp -v {} ./index.md \;
+        # Copy info.md to all directories (excluding 'images' directories)
+        find . -type d -not -name "images" -execdir cp -v $WSTG_BASE/www/$VERSION/info.md {} \;
+        # Set stable_version in site config
+        yq w $WWW_BASE/_config.yml stable_version $VERSION |sponge $WWW_BASE/_config.yml
+    - name: Setup Navigation (Versioned)
+      run: |
+        # Copy the current ToC for manipulation
+        cp $WSTG_BASE/document/README.md $WSTG_BASE/www/$VERSION/.
+        cd $WSTG_BASE/www/$VERSION/
+        # Create new navigation details from ToC
+        # Handle numbered entries
+        sed -i -E 's/^#{2,5}\s([0-9.]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
+        # Handle un-numbered entries
+        sed -i -E 's/^#{2,5}\s\[(.*?)\]\((.*?)\)/- title: '\''\1'\''\n  url: \2/g' README.md
+        # Remove the title from the README (first line)
+        sed -i '1d' README.md
+        # Find the anchor links (URL fragments) and lowercase them
+        sed -i -E 's/\.md#(.*)$/\.md#\L\1/g' README.md
+        # Switch .md references to .html
+        sed -i 's/.md/.html/g' README.md
+        # Add the leadin and add the generated yaml
+        cat prepend.nav > $VERSION.yaml && cat README.md >> $VERSION.yaml
+        # Copy the navigation yaml to _data
+        cp $VERSION.yaml $WWW_BASE/_data/.
+    - name: Push Feature Branch and Raise PR
+      run: |
+        cd $WWW_BASE
+        git remote set-url origin https://$GITHUB_USER:${{ secrets.wstg_deploy_token }}@github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
+        git add .
+        git commit -m "Publish Stable and $VERS_TAG - $SHORT_DATE" -m "Updates based on $SRC_BASE $VERS_TAG"
+        git push --set-upstream origin $BRANCH_STAMP
+        hub pull-request --no-edit

--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -31,10 +31,10 @@ jobs:
       run : |
         # Setup some env vars etc for future use
         # Extract version from tag ref
-        VERS_TAG=${GITHUB_REF/refs\/tags\//}
-        echo ::set-env name=VERS_TAG::$VERS_TAG
-        VERSION=$(echo $VERS | tr -d .)
-        echo ::set-env name=VERSION::$VERSION
+        VERSION_TAG=${GITHUB_REF/refs\/tags\//}
+        echo ::set-env name=VERSION_TAG::$VERSION_TAG
+        VERSION_PATH=$(echo $VERSION_TAG | tr -d .)
+        echo ::set-env name=VERSION_PATH::$VERSION_PATH
         cd wstg
         echo ::set-env name=WSTG_BASE::"$(pwd)"
         echo ::set-env name=SRC_BASE::"OWASP/wstg@"$(git log -1 --format=format:%h)
@@ -45,7 +45,7 @@ jobs:
     - name: Create Feature Branch
       run: |
         cd $WSTG_BASE
-        git checkout tags/$VERS_TAG -b ver-branch
+        git checkout tags/$VERSION_TAG -b ver-branch
         cd $WWW_BASE
         git remote add origin https://github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         # Checkout what will be the new feature branch
@@ -56,9 +56,9 @@ jobs:
         # Copy new 'stable' content
         cp -R $WSTG_BASE/document/* ./stable
         # Create version directory
-        mkdir $VERSION
+        mkdir $VERSION_PATH
         # Copy new version content
-        cp -R $WSTG_BASE/document/* ./$VERSION
+        cp -R $WSTG_BASE/document/* ./$VERSION_PATH
     - name: Modify Files for Web Deployment (Stable)
       run: |
         cd $WWW_BASE/stable
@@ -90,20 +90,20 @@ jobs:
         cp stable.yaml $WWW_BASE/_data/.
     - name: Modify Files for Web Deployment (Versioned)
       run: |
-        cd $WWW_BASE/$VERSION
+        cd $WWW_BASE/$VERSION_PATH
         # Append front mater
-        for FILE in `find . -type f -name "*.md"`; do cat $WSTG_BASE/www/$VERSION/prepend.txt $FILE | sponge $FILE; done
+        for FILE in `find . -type f -name "*.md"`; do cat $WSTG_BASE/www/$VERSION_PATH/prepend.txt $FILE | sponge $FILE; done
         # Duplicate README.md as index.md in case people forcefully browse to directory bases
         find . -type f -name "README.md" -execdir cp -v {} ./index.md \;
         # Copy info.md to all directories (excluding 'images' directories)
-        find . -type d -not -name "images" -execdir cp -v $WSTG_BASE/www/$VERSION/info.md {} \;
+        find . -type d -not -name "images" -execdir cp -v $WSTG_BASE/www/$VERSION_PATH/info.md {} \;
         # Set stable_version in site config
-        yq w $WWW_BASE/_config.yml stable_version $VERSION |sponge $WWW_BASE/_config.yml
+        yq w $WWW_BASE/_config.yml stable_version $VERSION_PATH |sponge $WWW_BASE/_config.yml
     - name: Setup Navigation (Versioned)
       run: |
         # Copy the current ToC for manipulation
-        cp $WSTG_BASE/document/README.md $WSTG_BASE/www/$VERSION/.
-        cd $WSTG_BASE/www/$VERSION/
+        cp $WSTG_BASE/document/README.md $WSTG_BASE/www/$VERSION_PATH/.
+        cd $WSTG_BASE/www/$VERSION_PATH/
         # Create new navigation details from ToC
         # Handle numbered entries
         sed -i -E 's/^#{2,5}\s([0-9.]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
@@ -116,14 +116,14 @@ jobs:
         # Switch .md references to .html
         sed -i 's/.md/.html/g' README.md
         # Add the leadin and add the generated yaml
-        cat prepend.nav > $VERSION.yaml && cat README.md >> $VERSION.yaml
+        cat prepend.nav > $VERSION_PATH.yaml && cat README.md >> $VERSION_PATH.yaml
         # Copy the navigation yaml to _data
-        cp $VERSION.yaml $WWW_BASE/_data/.
+        cp $VERSION_PATH.yaml $WWW_BASE/_data/.
     - name: Push Feature Branch and Raise PR
       run: |
         cd $WWW_BASE
         git remote set-url origin https://$GITHUB_USER:${{ secrets.wstg_deploy_token }}@github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         git add .
-        git commit -m "Publish Stable and $VERS_TAG - $SHORT_DATE" -m "Updates based on $SRC_BASE $VERS_TAG"
+        git commit -m "Publish Stable and $VERSION_TAG - $SHORT_DATE" -m "Updates based on $SRC_BASE $VERSION_TAG"
         git push --set-upstream origin $BRANCH_STAMP
         hub pull-request --no-edit

--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -77,7 +77,7 @@ jobs:
         # Handle numbered entries
         sed -i -E 's/^#{2,5}\s([0-9.]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
         # Handle un-numbered entries
-        sed -i -E 's/^#{2,5}\s\[(.*?)\]\((.*?)\)/- title: '\''\1'\''\n  url: \2/g' README.md
+        sed -i -E 's/^#{2,5}\s([a-zA-Z. ]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
         # Remove the title from the README (first line)
         sed -i '1d' README.md
         # Find the anchor links (URL fragments) and lowercase them
@@ -108,7 +108,7 @@ jobs:
         # Handle numbered entries
         sed -i -E 's/^#{2,5}\s([0-9.]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
         # Handle un-numbered entries
-        sed -i -E 's/^#{2,5}\s\[(.*?)\]\((.*?)\)/- title: '\''\1'\''\n  url: \2/g' README.md
+        sed -i -E 's/^#{2,5}\s([a-zA-Z. ]*\s)\[(.*?)\]\((.*?)\)/- title: '\''\1\2'\''\n  url: \3/g' README.md
         # Remove the title from the README (first line)
         sed -i '1d' README.md
         # Find the anchor links (URL fragments) and lowercase them

--- a/www/stable/README.md
+++ b/www/stable/README.md
@@ -1,0 +1,3 @@
+# www/stable
+
+This directory contains github action dependencies for deployment of content to the `stable` version on the owasp.org project website.

--- a/www/stable/info.md
+++ b/www/stable/info.md
@@ -1,0 +1,1 @@
+{% include navigation.html collection="stable" %}

--- a/www/stable/prepend.nav
+++ b/www/stable/prepend.nav
@@ -1,0 +1,2 @@
+docs_list_title: WSTG Contents
+docs:

--- a/www/stable/prepend.nav
+++ b/www/stable/prepend.nav
@@ -1,2 +1,2 @@
-docs_list_title: WSTG Contents
+docs_list_title: WSTG Contents (Stable)
 docs:

--- a/www/stable/prepend.txt
+++ b/www/stable/prepend.txt
@@ -1,0 +1,7 @@
+---
+
+layout: col-document
+title: WSTG - Stable
+tags: WSTG
+
+---

--- a/www/v41/README.md
+++ b/www/v41/README.md
@@ -1,0 +1,3 @@
+# www/v4.1
+
+This directory contains github action dependencies for deployment of content to the `v4.1` version on the owasp.org project website.

--- a/www/v41/info.md
+++ b/www/v41/info.md
@@ -1,0 +1,1 @@
+{% include navigation.html collection="v41" %}

--- a/www/v41/prepend.nav
+++ b/www/v41/prepend.nav
@@ -1,0 +1,2 @@
+docs_list_title: WSTG Contents
+docs:

--- a/www/v41/prepend.nav
+++ b/www/v41/prepend.nav
@@ -1,2 +1,2 @@
-docs_list_title: WSTG Contents
+docs_list_title: WSTG Contents (v4.1)
 docs:

--- a/www/v41/prepend.txt
+++ b/www/v41/prepend.txt
@@ -1,0 +1,7 @@
+---
+
+layout: col-document
+title: WSTG - v4.1
+tags: WSTG
+
+---


### PR DESCRIPTION
Triggered when a tag in the form `v<semver>` is applied by someone in the core team.

Sets up `/stable` and `/v<semver_withoutperiod>` (ex: `v41` for tag `v4.1`).

This PR also adds the ancillary files for v41 and stable. In the future ancillary files will have to be added as one of the last PRs before tagging occurs (like `www/v41` included here).

Note one of the steps in the versioned work is to set `stable_version` in `_config.yml`, this variable is currently un-used but we may have use for it in the future for linking or banner control.

Please review this job thoroughly so that we can avoid the misses we had on the 'latest' deploy job :wink:

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>