### PR TITLE
Workround for duplicate fragment links issue in v4.1 PDF build

### DIFF
--- a/pdf/scripts/make-pdf.sh
+++ b/pdf/scripts/make-pdf.sh
@@ -58,6 +58,11 @@ sed 's/\(^#\{5\} \) *\([^\n]\+\?\))*\(\?\:\n\+\|$\)/<h5 id=\"\2\">\2<\/h5>/' | \
 sed 's/\[\([^\[]*\)\]([^\[]*[0-9]\-\([^(]*\.md\))/<a href=\"#\2\">\1<\/a>/g' | \
 # Sed section 15: Set href for Appendix internal links. Remove subsection numbers from href.
 sed 's/\[\([^\[]*\)\]([^\[]*[ABCDE]-\([^(]*\.md\))/<a href=\"#\2\">\1<\/a>/g' | \
+# Sed section: Workaround to address the bug in duplicate fragment links in 4.1.
+sed 's/\[\([^\n]\+\)\](#tools)/\1/i' |\
+sed 's/\[\([^\n]\+\)\](#references)/\1/i' |\
+sed 's/\[\([^\n]\+\)\](#Remediation)/\1/i' |\
+sed 's/\[\([^\n]\+\)\]([^\n]\+.md#remediation)/\1/i' | \
 # Sed section 16: Correct Markdown file links with fragment identifiers. Remove file path and keep fragment identifier alone.
 sed 's/\[\([^\n]\+\)\]([^\n]\+.md#\([^\)]\+\))/<a href=\"#\2\">\1<\/a>/' | \
 # Sed section 17: Correct Markdown links with fragment identifiers.


### PR DESCRIPTION
This PR covers issue #<issue number>.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Remove broken links due to duplicate fragment in PDF build
   - `01-Information_Gathering/06-Identify_Application_Entry_Points.md`
  :19:(See `[tools](#tools)`).
   - `01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md`
  :51:(see an example in `[Remediation](#Remediation)` chapter).
   - `07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md`
  :136: `[RFC](#references)`
  - `11-Client_Side_Testing/10-Testing_WebSockets.md`
  :35: ` [Tools](#Tools)`
  - `11-Client_Side_Testing/10-Testing_WebSockets.md`
  :58:`[Tools](#Tools)`
  - `07-Input_Validation_Testing/05.8-Testing_for_Client_Side.md`
  :57: `[Testing for SQL Injection's Remediation Section](05-Testing_for_SQL_Injection.md#remediation)`.

