### PR TITLE
Fix typos in 04-Testing_for_Weak_Encryption.md

### DIFF
--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption.md
@@ -42,7 +42,7 @@ ECDH、ECDSA: 256 bits
 
 `MD4, MD5, RC4, RC2, DES, Blowfish, SHA-1, ECB`
 
-- For Java implementation, the following API is related to encyprtion. Review the parameters of the encryption implementation. For example,
+- For Java implementation, the following API is related to encryption. Review the parameters of the encryption implementation. For example,
 
 ```java
 SecretKeyFactory(SecretKeyFactorySpi keyFacSpi, Provider provider, String algorithm)
@@ -77,7 +77,7 @@ cipher.init(..., s);
  cipher.init(Cipher.ENCRYPT_MODE, skey, iv);
 ```
 
-- In Java, search for MessageDigest to check if weak hash althorithm (MD5 or CRC) is used. For example:
+- In Java, search for MessageDigest to check if weak hash algorithm (MD5 or CRC) is used. For example:
 
 `MessageDigest md5 = MessageDigest.getInstance("MD5");`
 
@@ -103,7 +103,7 @@ private static byte[] pbkdf2(char[] password, byte[] salt, int iteration
 
 ```text
 User related keywords: name, root, su, superuser, login, username, uid
-Key related keywords: public key, AK, SK, secret Key,  private key, passwd, password, pwd, share key, cryto, base64
+Key related keywords: public key, AK, SK, secret Key, private key, passwd, password, pwd, share key, cryto, base64
 Other common senstive keywords: sysadmin, root, privilege, pass, key, code, master, admin, uname, session, joken, Oauth, privatekey
 ```
 


### PR DESCRIPTION
This PR covers issue #476 

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Fix the following typos:
    1. "encyprtion" instead of "encryption".
    2. Two blank spaces instead of one in Key, private key.
    3. "althorithm" instead of "algorithm"

Closes #476 