### PR TITLE
Fix incorrect heading level in 09-Testing_for_Clickjacking.md

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -473,7 +473,7 @@
 				[
 					"encyprtion",
 					"encryption"
-				]
+				],
 				[
 					"flacky test(s)?",
 					"flaky test$1"

--- a/Testing_for_Server-Side_Request_Forgery.md
+++ b/Testing_for_Server-Side_Request_Forgery.md
@@ -4,7 +4,7 @@
 
 In a Server-Side Request Forgery (SSRF) attack, the attacker can abuse functionality on the server to read or update internal resources. The attacker can supply or a modify a request which the code running on the server will process. By carefully selecting the details, the attacker may be able to read server configuration such as AWS metadata, connect to internal services like HTTP enabled databases, or perform POST requests towards internal services which are not intended to be exposed.
 
-### Description
+## Description
 
 The target application may have functionality for importing data from a URL, publishing data to a URL, or otherwise reading data from a request that can be tampered with. The attacker modifies the calls to this functionality by supplying a completely different request or by manipulating how requests are built (path traversal, etc.).
 
@@ -15,9 +15,9 @@ Some common vulnerabilities related to server-side request forgery:
 - SQL injection
 - Link Injection
 
-### How to Test
+## How to Test
 
-#### Case I: Endpoints Which Fetch External/Internal Resources
+### Case I: Endpoints Which Fetch External/Internal Resources
 
 With GET request:
 
@@ -34,7 +34,7 @@ Host: example.com
 url=https://hacker.com/as&name2=value2
 ```
 
-#### Case II: PDF Generators
+### Case II: PDF Generators
 
 There are some cases where server converts uploaded file to a pdf.Try injecting `<iframe>`, `<img>`, `<base>` or `<script>` elements or CSS url() functions pointing to internal services.
 

--- a/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking.md
+++ b/document/4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking.md
@@ -22,7 +22,7 @@ The victim surfs the attacker's web page with the intention of interacting with 
 
 The power of this method is that the actions performed by the victim are originated from the hidden but authentic target web page. Consequently, some of the anti-CSRF protections deployed by the developers to protect the web page from CSRF attacks could be bypassed.
 
-### How to Test
+## How to Test
 
 As mentioned above, this type of attack is often designed to allow an attacker to induce users’ actions on the target site, even if anti-CSRF tokens are being used. Testing should be conducted to determine if website pages are vulnerable to clickjacking attacks.
 


### PR DESCRIPTION
Align the "How to Test" header to other document using H2 instead of H3

This PR covers issue #<issue number>.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Standardise the document header format to other wstg document

Thank you for your contribution!