### PR TITLE
Add Action to refresh stale issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/fix-request.md
+++ b/.github/ISSUE_TEMPLATE/fix-request.md
@@ -2,7 +2,7 @@
 name: Fix Request
 about: Create a report to help us improve
 title: ''
-labels: revise
+labels: revise, help wanted
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-content.md
+++ b/.github/ISSUE_TEMPLATE/new-content.md
@@ -2,7 +2,7 @@
 name: Add New Content
 about: Suggest additions to the Testing Guide
 title: ''
-labels: new
+labels: new, help wanted
 assignees: ''
 
 ---

--- a/.github/workflows/refresh-stale.yml
+++ b/.github/workflows/refresh-stale.yml
@@ -1,0 +1,21 @@
+name: Refresh Stale Issues with Help Wanted Label
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been inactive for 30 days. To give everyone a chance to contribute, we are releasing it to new contributors. Please comment if you are still working on it!'
+        stale-issue-label: 'help wanted'
+        exempt-issue-labels: 'help wanted'
+        stale-pr-message: 'This PR has been inactive for 30 days. To give everyone a chance to contribute, we are releasing it for new contributors to take over. Please comment if you are still working on it!'
+        stale-pr-label: 'help wanted'
+        exempt-pr-labels: 'help wanted'
+        remove-stale-when-updated: false
+        days-before-stale: 30
+        days-before-close: -1

--- a/.github/workflows/refresh-stale.yml
+++ b/.github/workflows/refresh-stale.yml
@@ -10,10 +10,10 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been inactive for 30 days. To give everyone a chance to contribute, we are releasing it to new contributors. Please comment if you are still working on it!'
+        stale-issue-message: 'Please comment if you are still working on this issue, as it has been inactive for 30 days. To give everyone a chance to contribute, we are releasing it to new contributors.'
         stale-issue-label: 'help wanted'
         exempt-issue-labels: 'help wanted'
-        stale-pr-message: 'This PR has been inactive for 30 days. To give everyone a chance to contribute, we are releasing it for new contributors to take over. Please comment if you are still working on it!'
+        stale-pr-message: 'Please comment if you are still working on this PR, as it has been inactive for 30 days. To give everyone a chance to contribute, we are releasing it for new contributors to take over.'
         stale-pr-label: 'help wanted'
         exempt-pr-labels: 'help wanted'
         remove-stale-when-updated: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Keeping the project up to date and looking spiffy is a group effort! The WSTG is
 
 When submitting your [pull request](#how-to-submit-a-pull-request), reviewers and editors should link contributions to an issue:
 
-1. Choose an [open and unassigned issue](https://github.com/OWASP/wstg/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee) to work on, or [open an issue](https://github.com/OWASP/wstg/issues/new/choose) yourself. Post a comment in the issue and request to be assigned to it.
+1. Choose an [open issue with the `help wanted` label](https://github.com/OWASP/wstg/labels/help%20wanted) to work on, or [open an issue](https://github.com/OWASP/wstg/issues/new/choose) yourself. Post a comment in the issue and request to be assigned to it.
 2. Create and switch to a new local branch with the name `fix-<issue number>`. For example, `git checkout -b fix-88`.
 
 ### Technical Review

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Linking to Web Security Testing Guide scenarios should be done using versioned l
 
 We are actively inviting new contributors! To start, read the [contribution guide](CONTRIBUTING.md).
 
+First time here? Here are [GitHub's suggestions for first-time contributors](https://github.com/OWASP/wstg/contribute) to this repository.
+
 This project is only possible thanks to the work of many dedicated volunteers. Everyone is encouraged to help in ways large and small. Here are a few ways you can help:
 
 - Read the current content and help us fix any spelling mistakes or grammatical errors.


### PR DESCRIPTION
- Direct new contributors to choose from unassigned issues with the "help
wanted" label
- Apply the "help wanted" label to new Fix Request and New Content
issues via ISSUE_TEMPLATE
- Maintainers should remove the "help wanted" label when an issue is
assigned
- Stale bot will re-apply the "help wanted" label to issues that are
inactive for 30 days
- Maintainers should unassign these refreshed issues if the assignee
does not respond