### PR TITLE
fix of link to MF Fortify

### DIFF
--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -95,7 +95,7 @@
 - [SAINT](https://www.carson-saint.com/)
 - [QualysGuard WAS](https://www.qualys.com/apps/web-app-scanning/)
 - [IndusGuard Web](https://www.indusface.com/products/application-security/web-application-scanning/)
-- [Fortify WebInspect](https://www.microfocus.com/en-us/products/application-security-testing/overview)
+- [Fortify WebInspect](https://www.microfocus.com/en-us/solutions/application-security)
 
 ### Linux Distrubtion
 
@@ -130,7 +130,7 @@
 - [Veracode](https://www.veracode.com/)
 - [Peach Fuzzer](https://www.peach.tech/)
 - [Burp Suite](https://portswigger.net/burp/)
-- [Fortify SCA](https://www.microfocus.com/en-us/products/application-security-testing/overview)
+- [Fortify SCA](https://www.microfocus.com/en-us/solutions/application-security)
 
 ## Acceptance Testing Tools
 


### PR DESCRIPTION
This PR closes OWASP/wstg#529 .

- [X] This PR handles the issue and requires no additional PRs.
- [X] You have validated the need for this change.

**What did this PR accomplish?**

URL to Micro Focus Fortify corrected to https://www.microfocus.com/en-us/solutions/application-security
