### PR TITLE
Implement pull_request_target for link checking

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,7 +1,7 @@
 name: Markdown Link Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - master
     paths:
@@ -42,9 +42,20 @@ jobs:
         cat log | awk -v RS="FILE:" 'match($0, /(\S*\.md).*\[✖\].*(\d*\slinks\schecked\.)(.*)/, arr ) { print "FILE:"arr[1] arr[3] > "brokenlinks.txt"}'
         cat brokenlinks.txt
         rm -f err log
+        links=`cat brokenlinks.txt`
+        links="${links//'%'/'%25'}"
+        links="${links//$'\n'/'%0A'}"
+        links="${links//$'\r'/'%0D'}"
+        echo ::set-output name=links::**Following links are broken:** %0A$links
     - name: Upload list of broken links
-      if: failure() && github.event_name == 'pull_request'
+      if: failure()
       uses: actions/upload-artifact@v1
       with:
         name: broken-links
         path: brokenlinks.txt
+    - name: Comment broken links
+      if: failure()
+      uses: thollander/actions-comment-pull-request@1.0.0
+      with:
+        message: ${{ steps.brokenlinks.outputs.links }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See if `pull_request_target` resolves commenting difficulties, per:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>