### PR TITLE
Update workflows README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,7 +4,7 @@
 
 For building PDFs at release.
 
-- Trigger: Tag applied to repository.
+- Trigger: Tag applied to repository. Manual (`workflow_dispatch`), GitHub web UI.
 - See: `/pdf/` in the root of the repository.
 
 ## `dummy.yml`


### PR DESCRIPTION
Clarify that the pdf build can now be triggered manually.