### PR TITLE
Preserve line breaks in linting comments

### DIFF
--- a/.github/workflows/md-lint-check.yml
+++ b/.github/workflows/md-lint-check.yml
@@ -30,6 +30,9 @@ jobs:
       run: |
         cat lint.txt
         ISSUES=$(cat lint.txt)
+        ISSUES="${ISSUES//'%'/'%25'}"
+        ISSUES="${ISSUES//$'\n'/'%0A'}"
+        ISSUES="${ISSUES//$'\r'/'%0D'}"
         echo ::set-output name=ISSUES::**The following issues were identified:** %0A$ISSUES
     - name: Attach Linting Issues
       if: failure()

--- a/.github/workflows/md-textlint-check.yml
+++ b/.github/workflows/md-textlint-check.yml
@@ -48,6 +48,9 @@ jobs:
       run: |
         cat log.txt
         MISTAKES=$(cat log.txt|grep -v '✔ Fixed'|tr '✔' '✖')
+        MISTAKES="${MISTAKES//'%'/'%25'}"
+        MISTAKES="${MISTAKES//$'\n'/'%0A'}"
+        MISTAKES="${MISTAKES//$'\r'/'%0D'}"
         echo ::set-output name=MISTAKES::**The following mistakes were identified:** %0A$MISTAKES
     - name: Attach Mistakes
       if: failure()


### PR DESCRIPTION
Attempts to maintain line breaks in the linting comments similar to what the link check output already does (https://github.com/OWASP/wstg/blob/master/.github/workflows/md-link-check.yml)