### PR TITLE
Fix 578: Linter can now handle triple backticks and comment

### DIFF
--- a/.github/workflows/md-lint-check.yml
+++ b/.github/workflows/md-lint-check.yml
@@ -29,6 +29,7 @@ jobs:
       if: failure()
       run: |
         cat lint.txt
+        sed -i 's/```/triple-backtick/g' lint.txt
         ISSUES=$(cat lint.txt)
         ISSUES="${ISSUES//'%'/'%25'}"
         ISSUES="${ISSUES//$'\n'/'%0A'}"


### PR DESCRIPTION
This PR closes OWASP/wstg#578.

- [ ] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- md-lint-check.yml > Use sed to replace triple backtick with the phrase "triple-backtick" so that it won't cause problems when passed as the content of a comment.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>