### PR TITLE
Update contribution info following root cleanup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,13 @@
         "[markdown]": {
             "editor.wordWrap": "bounded",
             "editor.wordWrapColumn": 100,
-            "editor.quickSuggestions": false,
+            "editor.quickSuggestions": false
         },
         "markdown.extension.toc.levels": "2..6",
         "markdown.preview.fontSize": 21,
+        "markdownlint.config": {
+            "extends": "/root/workspace/wstg/.github/configs/.markdownlint.json"
+        }
     },
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [

--- a/.gitignore
+++ b/.gitignore
@@ -69,11 +69,7 @@ $RECYCLE.BIN/
 *.lnk
 
 ### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,11 @@ Once the PR is complete, we'll merge it! At that point, you may like to add your
 1. [Create an account on GitHub](https://help.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account).
 2. Install [Visual Studio Code](https://code.visualstudio.com/) and this [Markdown linter plugin](https://github.com/DavidAnson/vscode-markdownlint#install). We use this linter to help keep the project content consistent and pretty.
 
-    1. Goto "Settings" (the gear icon).
-    2. Expand "Extensions", and find "markdownlint".
-    3. Just below "Markdownlint: config" click the "Edit in Settings.json" link.
-    4. Add the following:
+    1. From the gear icon/menu select "Settings".
+    2. Select the "Workspace" tab.
+    3. Expand "Extensions", and find "markdownlint".
+    4. Just below "Markdownlint: config" click the "Edit in settings.json" link.
+    5. Add the following:
 
     ```json
     "markdownlint.config": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,18 @@ Once the PR is complete, we'll merge it! At that point, you may like to add your
 
 1. [Create an account on GitHub](https://help.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account).
 2. Install [Visual Studio Code](https://code.visualstudio.com/) and this [Markdown linter plugin](https://github.com/DavidAnson/vscode-markdownlint#install). We use this linter to help keep the project content consistent and pretty.
+
+    1. Goto "Settings" (the gear icon).
+    2. Expand "Extensions", and find "markdownlint".
+    3. Just below "Markdownlint: config" click the "Edit in Settings.json" link.
+    4. Add the following:
+
+    ```json
+    "markdownlint.config": {
+      "extends": ".github/configs/.markdownlint.json"
+    }
+    ```
+
 3. Fork and clone your own copy of the repository. Here are complete instructions for [forking and syncing with GitHub](https://help.github.com/en/github/getting-started-with-github/fork-a-repo).
 
 ## Contributing with Codespaces


### PR DESCRIPTION
This PR fixes #607.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Update `.gitignore` to ignore the entire `.vscode` directory. 
- Update `CONTRIBUTING.md` to define how the workflow `.markdownlint.json` file can be referenced for use with markdownlint in VS Code.
- Update `devcontainer.json` to use the workflow `.markdownlint.json` (also fix syntatically incorrect trailing commas in two places).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>