### PR TITLE
Fix some formatting in the TLS testing guide

### DIFF
--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
@@ -56,12 +56,12 @@ As well as being cryptographically secure, the certificate must also be consider
 
 - Be within the defined validity period.
   - Any certificates issued after 1st September 2020 must not have a maximum lifespan of more than [398 days](https://blog.mozilla.org/security/2020/07/09/reducing-tls-certificate-lifespans-to-398-days/).
-  - Be signed by a trusted certificate authority (CA).
-    - This should either be a trusted public CA for externally facing applications, or an internal CA for internal applications.
-      - Don't flag internal applications as having untrusted certificates just because *your* system doesn't trust the CA.
-      - Have a Subject Alternate Name (SAN) that matches the hostname of the system.
-        - The Common Name (CN) field is ignored by modern browsers, which only look at the SAN.
-          - Make sure that you're accessing the system with the correct name (for example, if you access the host by IP then any certificate will be appear untrusted).
+- Be signed by a trusted certificate authority (CA).
+  - This should either be a trusted public CA for externally facing applications, or an internal CA for internal applications.
+  - Don't flag internal applications as having untrusted certificates just because *your* system doesn't trust the CA.
+- Have a Subject Alternate Name (SAN) that matches the hostname of the system.
+  - The Common Name (CN) field is ignored by modern browsers, which only look at the SAN.
+  - Make sure that you're accessing the system with the correct name (for example, if you access the host by IP then any certificate will be appear untrusted).
 
 Some certificates may be issued for wildcard domains (such as `*.example.org`), meaning that they can be valid for multiple subdomains. Although convenient, there are a number of security concerns around this that should be considered. These are discussed in the [OWASP Transport Layer Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html#carefully-consider-the-use-of-wildcard-certificates).
 


### PR DESCRIPTION
Not quite sure how it happened, but the formatting for one of the lists got screwed up in this.