### PR TITLE
Additional tests, WAST 4.07.04: Test results for .net core 3.1 and .net 5

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
@@ -45,6 +45,7 @@ Given the URL and querystring: `http://example.com/?color=red&color=blue`
   |--------------------------------|----------------|--------|
   | ASP.NET / IIS | All occurrences concatenated with a comma |  color=red,blue |
   | ASP / IIS     | All occurrences concatenated with a comma | color=red,blue |
+  | .NET 5 / Kestrel | All occurrences concatenated with a comma | color=red,blue |
   | PHP / Apache  | Last occurrence only | color=blue |
   | PHP / Zeus | Last occurrence only | color=blue |
   | JSP, Servlet / Apache Tomcat | First occurrence only | color=red |

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
@@ -45,6 +45,7 @@ Given the URL and querystring: `http://example.com/?color=red&color=blue`
   |--------------------------------|----------------|--------|
   | ASP.NET / IIS | All occurrences concatenated with a comma |  color=red,blue |
   | ASP / IIS     | All occurrences concatenated with a comma | color=red,blue |
+  | .NET Core 3.1 / Kestrel | All occurrences concatenated with a comma | color=red,blue |
   | .NET 5 / Kestrel | All occurrences concatenated with a comma | color=red,blue |
   | PHP / Apache  | Last occurrence only | color=blue |
   | PHP / Zeus | Last occurrence only | color=blue |


### PR DESCRIPTION
This PR covers issue #<issue number>.

- [ ] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.
Requested by @eoftedal 

**What did this PR accomplish?**

- Adding results for issuing same query parameter multiple times with different values on .NET 5 and .NET Core 3.1 running Kestrel. 