### PR TITLE
TLSv1.1 is deprecated and shouldn't be used

### DIFF
--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
@@ -27,6 +27,7 @@ There are a large number of protocol versions, ciphers, and extensions supported
 - [SSLv2 (DROWN)](https://drownattack.com/)
 - [SSLv3 (POODLE)](https://en.wikipedia.org/wiki/POODLE)
 - [TLSv1.0 (BEAST)](https://www.acunetix.com/blog/web-security-zone/what-is-beast-attack/)
+- [TLSv1.1 (Deprecated by RFC 8996)](https://tools.ietf.org/html/rfc8996)
 - [EXPORT ciphers suites (FREAK)](https://en.wikipedia.org/wiki/FREAK)
 - [NULL ciphers](https://www.rapid7.com/db/vulnerabilities/ssl-null-ciphers) ([they only provide authentication](https://tools.ietf.org/html/rfc4785)).
 - Anonymous ciphers (these may be supported on SMTP servers, as discussed in [RFC 7672](https://tools.ietf.org/html/rfc7672#section-8.2))


### PR DESCRIPTION
RFC 8996 has formally deprecated TLSv1.1.

There's not really any sinlge exploitable issue, just lots of smaller things that are bad about it. But no one should be using it, and we should be flagging if people are.