### PR TITLE
fix: remove duplicate test (WSTG-INPV-13)

### DIFF
--- a/checklist/checklist.json
+++ b/checklist/checklist.json
@@ -565,14 +565,6 @@
                   ]
                 }
                 ,{
-                "name":"Testing for Buffer Overflow",
-                "id":"WSTG-INPV-13",
-                "reference":"https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Buffer_Overflow.html",
-                "objectives":[
-                    ""
-                  ]
-                }
-                ,{
                 "name":"Testing for Format String Injection",
                 "id":"WSTG-INPV-13",
                 "reference":"https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection.html",


### PR DESCRIPTION
Duplicate key (WSTG-INPV-13) for "Testing for Buffer Overflow" and "Testing for Format String Injection".
Buffer Overflow has been removed from the other WSTG sources.