### PR TITLE
fix: Authentication Bypass in PHPBB sample code and affected version

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
@@ -96,19 +96,25 @@ The following figure shows that with a simple SQL injection attack, it is someti
 
 If an attacker has been able to retrieve the application source code by exploiting a previously discovered vulnerability (e.g., directory traversal), or from a web repository (Open Source Applications), it could be possible to perform refined attacks against the implementation of the authentication process.
 
-In the following example (PHPBB 2.0.13 - Authentication Bypass Vulnerability), at line 5 the unserialize() function parses a user supplied cookie and sets values inside the $row array. At line 10 the user's MD5 password hash stored inside the back end database is compared to the one supplied.
+In the following example (PHPBB 2.0.12 - Authentication Bypass Vulnerability), at line 2 the `unserialize()` function parses a user supplied cookie and sets values inside the `$sessiondata` array. At line 7 the user's MD5 password hash stored inside the back end database is compared to the one supplied.
 
 ```php
-if (isset($HTTP_COOKIE_VARS[$cookiename . '_sid']) {
+if (isset($HTTP_COOKIE_VARS[$cookiename . '_sid'])) {
     $sessiondata = isset($HTTP_COOKIE_VARS[$cookiename . '_data']) ? unserialize(stripslashes($HTTP_COOKIE_VARS[$cookiename . '_data'])) : array();
     $sessionmethod = SESSION_METHOD_COOKIE;
 }
-if(md5($password) == $row['user_password'] && $row['user_active']) {
-    $autologin = (isset($HTTP_POST_VARS['autologin'])) ? TRUE : 0;
+$auto_login_key = $userdata['user_password'];
+// We have to login automagically
+if( $sessiondata['autologinid'] == $auto_login_key )
+{
+    // autologinid matches password
+    $login = 1;
+    $enable_autologin = 1;
 }
+
 ```
 
-In PHP, a comparison between a string value and a boolean value (1 and `TRUE`) is always `TRUE`, so by supplying the following string (the important part is `b:1`) to the `unserialize()` function, it is possible to bypass the authentication control:
+In PHP, a comparison between a string value and a boolean value (1 and `TRUE`) is always `TRUE`, so by supplying the following string (the important part is `b:1`) to the `unserialize()` function, it is possible to bypass the authentication control and log in as administrator, whose `userid` is 2:
 
 ```text
 a:2:{s:11:"autologinid";b:1;s:6:"userid";s:1:"2";}
@@ -123,5 +129,5 @@ a:2:{s:11:"autologinid";b:1;s:6:"userid";s:1:"2";}
 
 ### Whitepapers
 
-- Mark Roxberry: "PHPBB 2.0.13 vulnerability"
+- Mark Roxberry: "PHPBB 2.0.12 vulnerability"
 - [David Endler: "Session ID Brute Force Exploitation and Prediction"](https://www.cgisecurity.com/lib/SessionIDs.pdf)

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
@@ -121,7 +121,7 @@ a:2:{s:11:"autologinid";b:1;s:6:"userid";s:1:"2";}  // original value: a:2:{s:11
 Let's disassemble what we did in this string:
 
 1. `autologinid` is now a boolean set to `true`: this can be seen by replacing the MD5 value of the password hash (`s:32:"8b8e9715d12e4ca12c4c3eb4865aaf6a"`) with `b:1`
-2. `userid` is now set to the admin id: this can be seen in the last piece of the string, where we replaced our regular user id (`s:4:"1337"`) with `s:1:"2"`
+2. `userid` is now set to the admin id: this can be seen in the last piece of the string, where we replaced our regular user ID (`s:4:"1337"`) with `s:1:"2"`
 
 ## Tools
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
@@ -24,8 +24,6 @@ Problems related to the authentication schema can be found at different stages o
 
 ## How to Test
 
-### Black-Box Testing
-
 There are several methods of bypassing the authentication schema that is used by a web application:
 
 - Direct page request ([forced browsing](https://owasp.org/www-community/attacks/Forced_browsing))
@@ -33,14 +31,14 @@ There are several methods of bypassing the authentication schema that is used by
 - Session ID prediction
 - SQL injection
 
-#### Direct Page Request
+### Direct Page Request
 
 If a web application implements access control only on the log in page, the authentication schema could be bypassed. For example, if a user directly requests a different page via forced browsing, that page may not check the credentials of the user before granting access. Attempt to directly access a protected page through the address bar in your browser to test using this method.
 
 ![Direct Request to Protected Page](images/Basm-directreq.jpg)\
 *Figure 4.4.4-1: Direct Request to Protected Page*
 
-#### Parameter Modification
+### Parameter Modification
 
 Another problem related to authentication design is when the application verifies a successful log in on the basis of a fixed value parameters. A user could modify these parameters to gain access to the protected areas without providing valid credentials. In the example below, the "authenticated" parameter is changed to a value of "yes", which allows the user to gain access. In this example, the parameter is in the URL, but a proxy could also be used to modify the parameter, especially when the parameters are sent as form elements in a POST request or when the parameters are stored in a cookie.
 
@@ -66,7 +64,7 @@ Content-Type: text/html; charset=iso-8859-1
 ![Parameter Modified Request](images/Basm-parammod.jpg)\
 *Figure 4.4.4-2: Parameter Modified Request*
 
-#### Session ID Prediction
+### Session ID Prediction
 
 Many web applications manage authentication by using session identifiers (session IDs). Therefore, if session ID generation is predictable, a malicious user could be able to find a valid session ID and gain unauthorized access to the application, impersonating a previously authenticated user.
 
@@ -80,7 +78,7 @@ In the following figure, values inside cookies change only partially, so it's po
 ![Partially Changed Cookie Values](images/Basm-sessid2.jpg)\
 *Figure 4.4.4-4: Partially Changed Cookie Values*
 
-#### SQL Injection (HTML Form Authentication)
+### SQL Injection (HTML Form Authentication)
 
 SQL Injection is a widely known attack technique. This section is not going to describe this technique in detail as there are several sections in this guide that explain injection techniques beyond the scope of this section.
 
@@ -92,33 +90,38 @@ The following figure shows that with a simple SQL injection attack, it is someti
 ![Simple SQL Injection Attack](images/Basm-sqlinj2.gif)\
 *Figure 4.4.4-6: Simple SQL Injection Attack*
 
-### Gray-Box Testing
+### PHP Loose Comparison
 
 If an attacker has been able to retrieve the application source code by exploiting a previously discovered vulnerability (e.g., directory traversal), or from a web repository (Open Source Applications), it could be possible to perform refined attacks against the implementation of the authentication process.
 
-In the following example (PHPBB 2.0.12 - Authentication Bypass Vulnerability), at line 2 the `unserialize()` function parses a user supplied cookie and sets values inside the `$sessiondata` array. At line 7 the user's MD5 password hash stored inside the back end database is compared to the one supplied.
+In the following example (PHPBB 2.0.12 - Authentication Bypass Vulnerability), at line 2 the `unserialize()` function parses a user supplied cookie and sets values inside the `$sessiondata` array. At line 7, the user's MD5 password hash stored inside the back end database (`$auto_login_key`) is compared to the one supplied (`$sessiondata['autologinid']`) by the user.
 
 ```php
-if (isset($HTTP_COOKIE_VARS[$cookiename . '_sid'])) {
-    $sessiondata = isset($HTTP_COOKIE_VARS[$cookiename . '_data']) ? unserialize(stripslashes($HTTP_COOKIE_VARS[$cookiename . '_data'])) : array();
-    $sessionmethod = SESSION_METHOD_COOKIE;
-}
-$auto_login_key = $userdata['user_password'];
-// We have to login automagically
-if( $sessiondata['autologinid'] == $auto_login_key )
-{
-    // autologinid matches password
-    $login = 1;
-    $enable_autologin = 1;
-}
+1. if (isset($HTTP_COOKIE_VARS[$cookiename . '_sid'])) {
+2.     $sessiondata = isset($HTTP_COOKIE_VARS[$cookiename . '_data']) ? unserialize(stripslashes($HTTP_COOKIE_VARS[$cookiename . '_data'])) : array();
+3.     $sessionmethod = SESSION_METHOD_COOKIE;
+4. }
+5. $auto_login_key = $userdata['user_password'];
+6. // We have to login automagically
+7. if( $sessiondata['autologinid'] == $auto_login_key )
+8. {
+9.     // autologinid matches password
+10.     $login = 1;
+11.     $enable_autologin = 1;
+12. }
 
 ```
 
-In PHP, a comparison between a string value and a boolean value (1 and `TRUE`) is always `TRUE`, so by supplying the following string (the important part is `b:1`) to the `unserialize()` function, it is possible to bypass the authentication control and log in as administrator, whose `userid` is 2:
+In PHP, a comparison between a string value and a `true` boolean value is always `true` (because the string contains a value), so by supplying the following string to the `unserialize()` function, it is possible to bypass the authentication control and log in as administrator, whose `userid` is 2:
 
-```text
-a:2:{s:11:"autologinid";b:1;s:6:"userid";s:1:"2";}
+```php
+a:2:{s:11:"autologinid";b:1;s:6:"userid";s:1:"2";}  // original value: a:2:{s:11:"autologinid";s:32:"8b8e9715d12e4ca12c4c3eb4865aaf6a";s:6:"userid";s:4:"1337";}
 ```
+
+Let's disassemble what we did in this string:
+
+1. `autologinid` is now a boolean set to `true`: this can be seen by replacing the MD5 value of the password hash (`s:32:"8b8e9715d12e4ca12c4c3eb4865aaf6a"`) with `b:1`
+2. `userid` is now set to the admin id: this can be seen in the last piece of the string, where we replaced our regular user id (`s:4:"1337"`) with `s:1:"2"`
 
 ## Tools
 
@@ -127,7 +130,5 @@ a:2:{s:11:"autologinid";b:1;s:6:"userid";s:1:"2";}
 
 ## References
 
-### Whitepapers
-
-- Mark Roxberry: "PHPBB 2.0.12 vulnerability"
+- [Niels Teusink: phpBB 2.0.12 authentication bypass](http://blog.teusink.net/2008/12/classic-bug-phpbb-2012-authentication.html)
 - [David Endler: "Session ID Brute Force Exploitation and Prediction"](https://www.cgisecurity.com/lib/SessionIDs.pdf)


### PR DESCRIPTION
**What did this PR accomplish?**

- Correct vulnerable application version number to 2.0.12 (vulnerability was present up to and including PHPBB 2.0.12, checked from code that 2.0.13 had the required patch)
- Provide correct example of vulnerable code and explanation (code sample had syntax error and part of it was copied from unrelated PHPBB component)

Tried to contact author of referenced whitepaper for confirmation, but got no response.