### PR TITLE
fix: password example rendering as table

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer.md
@@ -26,7 +26,7 @@ The problem with having users to generate their own questions is that it allows 
 
 - "What is 1+1?"
 - "What is your username?"
-- "My password is S3cur|ty!"
+- "My password is S3curIty!"
 
 ## Test Objectives
 


### PR DESCRIPTION
**What did this PR accomplish?**

- Avoid rendering password example as table by MarkDown (replace pipe `|` with `I`). Problem visible at https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer.html