### PR TITLE
Add a JWT testing guide.

### DIFF
--- a/checklist/Testing_Checklist.md
+++ b/checklist/Testing_Checklist.md
@@ -61,6 +61,7 @@ Note: The `Status` column can be set for values similar to "Pass", "Fail", "N/A"
 | WSTG-SESS-07      | Testing Session Timeout                                                    |        |       |
 | WSTG-SESS-08      | Testing for Session Puzzling                                               |        |       |
 | WSTG-SESS-09      | Testing for Session Hijacking                                              |        |       |
+| WSTG-SESS-10      | Testing JSON Web Tokens                                                    |        |       |
 | **WSTG-INPV**     | **Input Validation Testing**                                               |        |       |
 | WSTG-INPV-01      | Testing for Reflected Cross Site Scripting                                 |        |       |
 | WSTG-INPV-02      | Testing for Stored Cross Site Scripting                                    |        |       |

--- a/checklist/checklist.json
+++ b/checklist/checklist.json
@@ -453,6 +453,14 @@
                     "Hijack vulnerable cookies and assess the risk level."
                   ]
                 }
+                ,{
+                "name":"Testing JSON Web Tokens",
+                "id":"WSTG-SESS-10",
+                "reference":"https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-JSON_Web_Tokens.html", "objectives":[
+                    "Determine whether the JWTs expose sensitive information.",
+                    "Determine whether the JWTs can be tampered with or modified."
+                  ]
+                }
             ]
         }
         ,"Input Validation Testing": {

--- a/checklist/checklist.json
+++ b/checklist/checklist.json
@@ -453,14 +453,6 @@
                     "Hijack vulnerable cookies and assess the risk level."
                   ]
                 }
-                ,{
-                "name":"Testing JSON Web Tokens",
-                "id":"WSTG-SESS-10",
-                "reference":"https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-JSON_Web_Tokens.html", "objectives":[
-                    "Determine whether the JWTs expose sensitive information.",
-                    "Determine whether the JWTs can be tampered with or modified."
-                  ]
-                }
             ]
         }
         ,"Input Validation Testing": {

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -19,31 +19,66 @@
 
 ### Overview
 
-- What a JWT is
-    - Three b64 encoded parters (header, body, signature)
-- Common usage scenarios
+JWTs are are made up of three components:
+
+- The header
+- The payload (or body)
+- The signature
+
+Each component is Base64 encoded, and they are separated by periods (`.`). Note that the Base64 encoding used in a JWT strips out the equals signs (`=`), so you may need to add these back in to decode the sections.
+
+JWTs are used to share cryptographically signed claims between systems. They are frequently used as authentication tokens, particularly on REST APIs.
 
 ### Analyse the Contents
 
 #### Header
 
-- Header includes the algorithm
-    - Algorithms have type (RS/PS/HS/ES) and strength in bits
-    - Table of common algorithms
-    - Ideally should be `HSxxx` (for HMAC) or `ESxxx` for public key
-    - RSA (`RSxxx` and `PSxxx`) is legacy, but still acceptable
-    - [Other algorithms](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) may also be used, especially for encryption tokens
+The header of a defines the type of the token (typically `JWT`), and the algorithm used for the signature. A example decoded header is shown below:
 
-#### Body
+```json
+{
+  "alg": "HS256",
+  "typ": "JWT"
+}
+```
 
-- JWTs are not usually encrypted
-- Some standard fields (table)
-    - iss = Issuer
-    - iat = Issued At
-    - nbf = Not Before
-    - exp = Expiration Time
-- Can also include custom data
-    - May expose sensitive information
+There are three main types of algorithms that are used to calculate the signatures:
+
+| Algorithm | Description |
+|--------------|----------------|
+| HSxxx | HMAC using a secret key and SHA-xxx |
+| RSxxx and PSxxx | Public key signature using RSA |
+| ESxxx | Public key signature using ECDSA |
+
+There are also a wide range of [other algorithms](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) which may be used for encrypted tokens (JWEs), although these are less common.s
+
+#### Payload
+
+The payload of the JWT contains the actual data. An example payload is shown below:
+
+```json
+{
+  "username": "admininistrator",
+  "is_admin": true,
+  "iat": 1516239022,
+  "exp": 1516242622
+}
+```
+
+The payload is it not usually encrypted, so review it to determine whether there is any sensitive of potentially inappropriate data included within it.
+
+This JWT includes the username and administrative status of the user, as well as two standard claims (`iat` and `exp`). These claims are defined in [RFC 5719](https://tools.ietf.org/html/rfc7519#section-4.1), a brief summary of them is given in the table below:
+
+| Claim | Full Name | Description |
+|---------|-------------|-------------|
+| `iss` | Issuer | The identity of the party who issued the token. |
+| `iat` | Issued At | The Unix timestamp of when the token was issued. |
+| `nbf` | Not Before | The Unix timestamp of earliest date that the token can be used. |
+| `exp` | Expires | The Unix timestamp of when the token expires. |
+
+#### Signature
+
+The signature is calculated using the algorithm defined in the JWT header, and then Base64 encoded and appened to the token. Modifying any part of the JWT should cause the signature to be invalid, and the token to be rejected by the server.
 
 ### Review Usage
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -6,9 +6,9 @@
 
 ## Summary
 
-- JSON Web Tokens (JWTs) are cryptographically signed JSON tokens
-- Commonly used to authenticate on APIs
-- Lots of bad implementations and opportunities for things to go wrong
+JSON Web Tokens (JWTs) are cryptographically signed JSON tokens, intended to share claims between systems. They are are frequently used as authentication or session tokens, particularly on REST APIs.
+
+JWTs are a common source of vulnerabilities, both in how they are in implemented in applications, and in the underlying libraries. As they are used for authentication, a vulnerability can easily result in a complete compromise of the application.
 
 ## Test Objectives
 
@@ -26,8 +26,6 @@ JWTs are are made up of three components:
 - The signature
 
 Each component is Base64 encoded, and they are separated by periods (`.`). Note that the Base64 encoding used in a JWT strips out the equals signs (`=`), so you may need to add these back in to decode the sections.
-
-JWTs are used to share cryptographically signed claims between systems. They are frequently used as authentication tokens, particularly on REST APIs.
 
 ### Analyse the Contents
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -31,8 +31,8 @@
     - Algorithms have type (RS/PS/HS/ES) and strength in bits
     - Table of common algorithms
     - Ideally should be `HSxxx` (for HMAC) or `ESxxx` for public key
-    - `RSxxx` and `PSxxx` are acceptable
-    - Other algorithms may also be used, especially for encryption tokens
+    - RSA (`RSxxx` and `PSxxx`) is legacy, but still acceptable
+    - [Other algorithms](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) may also be used, especially for encryption tokens
 
 #### Body
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -43,10 +43,10 @@ The header of a defines the type of the token (typically `JWT`), and the algorit
 There are three main types of algorithms that are used to calculate the signatures:
 
 | Algorithm | Description |
-|--------------|----------------|
-| HSxxx | HMAC using a secret key and SHA-xxx |
-| RSxxx and PSxxx | Public key signature using RSA |
-| ESxxx | Public key signature using ECDSA |
+|-----------|-------------|
+| HSxxx | HMAC using a secret key and SHA-xxx. |
+| RSxxx and PSxxx | Public key signature using RSA. |
+| ESxxx | Public key signature using ECDSA. |
 
 There are also a wide range of [other algorithms](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) which may be used for encrypted tokens (JWEs), although these are less common.s
 
@@ -68,7 +68,7 @@ The payload is it not usually encrypted, so review it to determine whether there
 This JWT includes the username and administrative status of the user, as well as two standard claims (`iat` and `exp`). These claims are defined in [RFC 5719](https://tools.ietf.org/html/rfc7519#section-4.1), a brief summary of them is given in the table below:
 
 | Claim | Full Name | Description |
-|---------|-------------|-------------|
+|-------|-----------|-------------|
 | `iss` | Issuer | The identity of the party who issued the token. |
 | `iat` | Issued At | The Unix timestamp of when the token was issued. |
 | `nbf` | Not Before | The Unix timestamp of earliest date that the token can be used. |

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -1,4 +1,4 @@
-# Testing JSON Web Tokens (JWTs)
+# Testing JSON Web Tokens
 
 |ID          |
 |------------|

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -31,7 +31,7 @@ Each component is Base64 encoded, and they are separated by periods (`.`). Note 
 
 #### Header
 
-The header of a defines the type of the token (typically `JWT`), and the algorithm used for the signature. A example decoded header is shown below:
+The header defines the type of token (typically `JWT`), and the algorithm used for the signature. An example decoded header is shown below:
 
 ```json
 {
@@ -76,7 +76,7 @@ This JWT includes the username and administrative status of the user, as well as
 
 #### Signature
 
-The signature is calculated using the algorithm defined in the JWT header, and then Base64 encoded and appened to the token. Modifying any part of the JWT should cause the signature to be invalid, and the token to be rejected by the server.
+The signature is calculated using the algorithm defined in the JWT header, and then Base64 encoded and appended to the token. Modifying any part of the JWT should cause the signature to be invalid, and the token to be rejected by the server.
 
 ### Review Usage
 
@@ -113,9 +113,9 @@ If the application is using off-the-shelf or open source software, the first ste
 
 If there isn't a default, then it may be possible to crack guess or brute-force they key. The simplest way to do this is to use the [crackjwt.py](https://github.com/Sjord/jwtcrack) script, which simply requires the JWT and a dictionary file.
 
-A more powerful option is to convert convert the JWT into a format that can be used by [John the Ripper](https://github.com/openwall/john) using the [jwt2john.py](https://github.com/Sjord/jwtcrack/blob/master/jwt2john.py) script. John can then be used to carry out much more advanced attacks against the key.
+A more powerful option is to convert the JWT into a format that can be used by [John the Ripper](https://github.com/openwall/john) using the [jwt2john.py](https://github.com/Sjord/jwtcrack/blob/master/jwt2john.py) script. John can then be used to carry out much more advanced attacks against the key.
 
-If the JWT is large, it may exceed the maximum size supported by John. This can be worked around by increasing the value of the `SALT_LIMBS` variable in `/src/hmacSHA256_fmt_plug.c` (or the equivalent file for other HMAC formats) and recompiling John.
+If the JWT is large, it may exceed the maximum size supported by John. This can be worked around by increasing the value of the `SALT_LIMBS` variable in `/src/hmacSHA256_fmt_plug.c` (or the equivalent file for other HMAC formats) and recompiling John, as discussed in the following [GitHub issue](https://github.com/openwall/john/issues/1904).
 
 If this key can be obtained, then it is possible to create and sign arbitrary JWTs, which usually results in a complete compromise of the application.
 
@@ -123,11 +123,23 @@ If this key can be obtained, then it is possible to create and sign arbitrary JW
 
 If the application uses JWTs with public key based signatures, but does not check that the algorithm is correct, this can potentially exploit this in a signature type confusion attack. In order for this to be successful, the following conditions need to be met:
 
-- The application must use public key (i.e, `RSxxx` or `ESxxx`) to verify the JWT signature.
-- The application must not check which algorithm is actually used.
-- The public key used to verify the JWT must be available to the attacker.
+1. The application must expect the JWT to be signed with a public key based algorithm (i.e, `RSxxx` or `ESxxx`).
+2. The application must not check which algorithm the JWT is actually using for the signature.
+3. The public key used to verify the JWT must be available to the attacker.
 
-The main way that an attacker would be able to obtain the public key is if the application re-uses the same key for both signing JWTs and as part of the TLS certificate. This key can be downloaded from the server using a command such as the following:
+If all of these conditions are true, then an attacker can use the public key to sign the JWT using a HMAC based algorithm (such as `HS256`). For example, the [Node.JS jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken) library uses the same function for both public key and HMAC based tokens, as shown in the example below:
+
+```javascript
+// Verify a JWT signed using RS256
+jwt.verify(token, publicKey);
+
+// Verify a JWT signed using HS256
+jwt.verify(token, secretKey);
+```
+
+This means that if the JWT is signed using `publicKey` as a secret key for the `HS256` algorithm, the signature will be considered valid.
+
+In order to exploit this issue, the public key must be obtained. The most common way this can happen is if the application re-uses the same key for both signing JWTs and as part of the TLS certificate. In this case, the key can be downloaded from the server using a command such as the following:
 
 ```sh
 openssl s_client -connect example.org:443 | openssl x509 -pubkey -noout
@@ -135,11 +147,11 @@ openssl s_client -connect example.org:443 | openssl x509 -pubkey -noout
 
 Alternatively, the key may be available from a public file on the site at a common location such as `/.well-known/jwks.json`.
 
-In order to test this, modify the contents of the JWT, and then use the previously obtained public key to sign the JWT using the `HS256` algorithm. This is often difficult to perform when testing without access to the source code or implementation deatils, because the format of the key must be identical to the one used by the server, so issues such as emptyspace or CRLF encoding may result in the keys not matching.
+In order to test this, modify the contents of the JWT, and then use the previously obtained public key to sign the JWT using the `HS256` algorithm. This is often difficult to perform when testing without access to the source code or implementation details, because the format of the key must be identical to the one used by the server, so issues such as empty space or CRLF encoding may result in the keys not matching.
 
 ### Attacker Provided Public Key
 
-The JSON Web Signature (JWS) standard allows the key used to sign the token to be embedded in the header. If the library used to validate the token supports this, and doesn't check the key against a list of approved keys, this allows an attacker to sign an JWT with an arbitrary key that they provide.
+The [JSON Web Signature (JWS) standard](https://tools.ietf.org/html/rfc7515) (which defines the header and signatures used by JWTs) allows the key used to sign the token to be embedded in the header. If the library used to validate the token supports this, and doesn't check the key against a list of approved keys, this allows an attacker to sign an JWT with an arbitrary key that they provide.
 
 There are a variety of scripts that can be used to do this, such as [jwk-node-jose.py](https://github.com/zi0Black/POC-CVE-2018-0114) or [jwt_tool](https://github.com/ticarpi/jwt_tool).
 
@@ -152,6 +164,7 @@ There are a variety of scripts that can be used to do this, such as [jwk-node-jo
 ## Remediation
 
 - Use a secure and up to date library to handle JWTs.
+- Ensure that the signature is valid, and that it is using the expected algorithm.
 - Use a strong HMAC key or a unique private key to sign them.
 - Ensure that there is no sensitive information exposed in the payload.
 - Ensure that JWTs are securely stored and transmitted.

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -147,7 +147,9 @@ There are a variety of scripts that can be used to do this, such as [jwk-node-jo
 
 ## Related Test Cases
 
-TODO
+- [Testing for Sensitive Information Sent via Unencrypted Channels](../09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md).
+- [Testing for Cookie Attributes](../06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md).
+- [Testing Browser Storage](../11-Client-side_Testing/12-Testing_Browser_Storage.md).
 
 ## Remediation
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -82,10 +82,16 @@ The signature is calculated using the algorithm defined in the JWT header, and t
 
 ### Review Usage
 
-- How is JWT sent?
-- How is JWT stored?
-- Does JWT expire?
-- Can JWT be invalidated?
+As well as being cryptographically secure itself, the JWT also needs to be stored and sent in a secure manner. This should include checks that:
+
+- It is always [sent over encrypted (HTTPS) connections](../09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md).
+- If it is stored in a cookie, then it should be [marked with appropriate attributes](../06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md).
+- If it is stored in the browser storage, it should [use the sessionStorage rather than localStorage](../11-Client-side_Testing/12-Testing_Browser_Storage.md).
+
+The validity of the JWT should also be reviewed, based on the `iat`, `nbf` and `exp` claims, to determine that:
+
+- The JWT has a reasonable lifespan for the application.
+- Expired tokens are rejected by the application.
 
 ### Signature Verification
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -25,8 +25,25 @@
 
 ### Analyse the Contents
 
+#### Header
+
+- Header includes the algorithm
+    - Algorithms have type (RS/PS/HS/ES) and strength in bits
+    - Table of common algorithms
+    - Ideally should be `HSxxx` (for HMAC) or `ESxxx` for public key
+    - `RSxxx` and `PSxxx` are acceptable
+    - Other algorithms may also be used, especially for encryption tokens
+
+#### Body
+
 - JWTs are not usually encrypted
-- May expose sensitive information
+- Some standard fields (table)
+    - iss = Issuer
+    - iat = Issued At
+    - nbf = Not Before
+    - exp = Expiration Time
+- Can also include custom data
+    - May expose sensitive information
 
 ### Review Usage
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -74,6 +74,7 @@ TODO
 - [John the Ripper](https://github.com/openwall/john)
 - [jwt2john](https://github.com/Sjord/jwtcrack)
 - [jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker)
+- [JSON Web Tokens Burp Extension](https://portswigger.net/bappstore/f923cbf91698420890354c1d8958fee6)
 
 ## References
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -59,12 +59,17 @@
 
 ### Weak HMAC Keys
 
-- HMAC uses a secret key
-- Convert JWT into crackable format
-- Try and crack key
-    - jwt2john
-    - May need custom compiled john for long JWT (`SALT_LIMBS`)
-    - jwtcrack
+If the JWT is signed using a HMAC-based algorithm (such as HS256), the security of the signature is entirely reliant on the strength of the secret key used in the HMAC.
+
+If the application is using off-the-shelf or open source software, the first step should be go investigate the code, and see whether there is default HMAC signing key that is used.
+
+If there isn't a default, then it may be possible to crack guess or brute-force they key. The simplest way to do this is to use the [crackjwt.py](https://github.com/Sjord/jwtcrack) script, which simply requires the JWT and a dictionary file.
+
+A more powerful option is to convert convert the JWT into a format that can be used by [John the Ripper](https://github.com/openwall/john) using the [jwt2john.py](https://github.com/Sjord/jwtcrack/blob/master/jwt2john.py) script. John can then be used to carry out much more advanced attacks against the key.
+
+If the JWT is large, it may exceed the maximum size supported by John. This can be worked around by increasing the value of the `SALT_LIMBS` variable in `/src/hmacSHA256_fmt_plug.c` (or the equivalent file for other HMAC formats) and recompiling John.
+
+If this key can be obtained, then it is possible to create and sign arbitrary JWTs, which usually results in a complete compromise of the application.
 
 ### HMAC vs RSA Confusion
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -151,7 +151,11 @@ There are a variety of scripts that can be used to do this, such as [jwk-node-jo
 
 ## Remediation
 
-TODO
+- Use a secure and up to date library to handle JWTs.
+- Use a strong HMAC key or a unique private key to sign them.
+- Ensure that there is no sensitive information exposed in the payload.
+- Ensure that JWTs are securely stored and transmitted.
+- See the [OWASP JSON Web Tokens Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)
 
 ## Tools
 
@@ -164,3 +168,4 @@ TODO
 ## References
 
 - [RFC 7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
+- [OWASP JSON Web Token Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -99,7 +99,7 @@ As well as the public key and HMAC-based algorithms, the JWT specification also 
 
 This can be tested by modifying the signature algorithm (`alg`) in the JWT header to `none`, and resubmitting the JWT.
 
-Some implementation try and avoid this by blacklisting the use of the `none` algorithm. If this is done in a case-insensitive way, it may be possible to bypass by specifying an algorithm such as `NoNe`.
+Some implementation try and avoid this by explicitly blocking the use of the `none` algorithm. If this is done in a case-insensitive way, it may be possible to bypass by specifying an algorithm such as `NoNe`.
 
 ### Weak HMAC Keys
 
@@ -131,7 +131,7 @@ openssl s_client -connect example.org:443 | openssl x509 -pubkey -noout
 
 Alternatively, the key may be available from a public file on the site at a common location such as `/.well-known/jwks.json`.
 
-In order to test this, modify the contents of the JWT, and then use the previously obtained public key to sign the JWT using the `HS256` algorithm. This is often difficult to perform when testing from a black-box perspective, because the format of the key must be identical to the one used by the server, so issues such as whitespace or CRLF encoding may result in the keys not matching.
+In order to test this, modify the contents of the JWT, and then use the previously obtained public key to sign the JWT using the `HS256` algorithm. This is often difficult to perform when testing without access to the source code or implementation deatils, because the format of the key must be identical to the one used by the server, so issues such as emptyspace or CRLF encoding may result in the keys not matching.
 
 ### Attacker Provided RSA Key
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -75,6 +75,7 @@ TODO
 - [jwt2john](https://github.com/Sjord/jwtcrack)
 - [jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker)
 - [JSON Web Tokens Burp Extension](https://portswigger.net/bappstore/f923cbf91698420890354c1d8958fee6)
+- [ZAP JWT Add-on](https://github.com/SasanLabs/owasp-zap-jwt-addon)
 
 ## References
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -54,8 +54,17 @@
 
 ### Signature Verification
 
-- Signature may not be verified at all (`jwt.decode()` vs `jwt.verify()`)
-- `none` or `NoNe` algorithms may be allowed
+One of the most serious vulnerabilities encountered with JWTs is when the application fails to validate that the signature is correct. This usually occurs when a developer uses a function such as the NodeJS `jwt.deode()` function, which simply decodes the body of the JWT, rather than `jwt.verify()`, which verifies the signature before decoding the JWT.
+
+This can be easily tested for by modifying the body of the JWT without changing anything in the header or signature, submitting it in a request to see if the application accepts it.
+
+#### The None Algorithm
+
+As well as the public key and HMAC-based algorithms, the JWT specification also defines a signature algorithm called `none`. As the name suggests, this means that there is no signature for the JWT, allowing it to be modified.
+
+This can be tested by modifying the signature algorithm (`alg`) in the JWT header to `none`, and resubmitting the JWT.
+
+Some implementation try and avoid this by blacklisting the use of the `none` algorithm. If this is done in a case-insensitive way, it may be possible to bypass by specifying an algorithm such as `NoNe`.
 
 ### Weak HMAC Keys
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -139,10 +139,11 @@ Alternatively, the key may be available from a public file on the site at a comm
 
 In order to test this, modify the contents of the JWT, and then use the previously obtained public key to sign the JWT using the `HS256` algorithm. This is often difficult to perform when testing without access to the source code or implementation deatils, because the format of the key must be identical to the one used by the server, so issues such as emptyspace or CRLF encoding may result in the keys not matching.
 
-### Attacker Provided RSA Key
+### Attacker Provided Public Key
 
-- JSON Web Signature (JWS) allows embedding of public key in the header
-- Sign with our own private key and see if server trusts it
+The JSON Web Signature (JWS) standard allows the key used to sign the token to be embedded in the header. If the library used to validate the token supports this, and doesn't check the key against a list of approved keys, this allows an attacker to sign an JWT with an arbitrary key that they provide.
+
+There are a variety of scripts that can be used to do this, such as [jwk-node-jose.py](https://github.com/zi0Black/POC-CVE-2018-0114) or [jwt_tool](https://github.com/ticarpi/jwt_tool).
 
 ## Related Test Cases
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -20,6 +20,7 @@
 ### Overview
 
 - What a JWT is
+    - Three b64 encoded parters (header, body, signature)
 - Common usage scenarios
 
 ### Analyse the Contents
@@ -44,13 +45,21 @@
 - HMAC uses a secret key
 - Convert JWT into crackable format
 - Try and crack key
+    - jwt2john
+    - May need custom compiled john for long JWT (`SALT_LIMBS`)
+    - jwtcrack
 
 ### HMAC vs RSA Confusion
 
 - Obtain public key
-    - Public key may be in `/.well-known/jwks.json`
-    - Obtain public key from TLS cert (shouldn't be re-used, but may be)
+    - May be in `/.well-known/jwks.json`
+    - Can be obtained from TLS cert (shouldn't be re-used, but may be)
 - Use public key as a secret to calculate a HMAC
+
+### Attacker Provided RSA Key
+
+- JSON Web Signature (JWS) allows embedding of public key in the header
+- Sign with our own private key and see if server trusts it
 
 ## Related Test Cases
 
@@ -63,7 +72,7 @@ TODO
 ## Tools
 
 - [John the Ripper](https://github.com/openwall/john)
-- [jw2john](https://github.com/Sjord/jwtcrack)
+- [jwt2john](https://github.com/Sjord/jwtcrack)
 - [jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker)
 
 ## References

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -84,7 +84,6 @@ As well as being cryptographically secure itself, the JWT also needs to be store
 
 - It is always [sent over encrypted (HTTPS) connections](../09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md).
 - If it is stored in a cookie, then it should be [marked with appropriate attributes](../06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md).
-- If it is stored in the browser storage, it should [use the sessionStorage rather than localStorage](../11-Client-side_Testing/12-Testing_Browser_Storage.md).
 
 The validity of the JWT should also be reviewed, based on the `iat`, `nbf` and `exp` claims, to determine that:
 
@@ -193,5 +192,6 @@ There are a variety of scripts that can be used to do this, such as [jwk-node-jo
 
 ## References
 
+- [RFC 7515 JSON Web Signature (JWS)](https://tools.ietf.org/html/rfc7515)
 - [RFC 7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
 - [OWASP JSON Web Token Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-- JWTs are cryptographically signed JSON tokens
+- JSON Web Tokens (JWTs) are cryptographically signed JSON tokens
 - Commonly used to authenticate on APIs
 - Lots of bad implementations and opportunities for things to go wrong
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -2,7 +2,7 @@
 
 |ID          |
 |------------|
-|WSTG-SESS-010|
+|WSTG-SESS-10|
 
 ## Summary
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -155,7 +155,7 @@ There are a variety of scripts that can be used to do this, such as [jwk-node-jo
 - Use a strong HMAC key or a unique private key to sign them.
 - Ensure that there is no sensitive information exposed in the payload.
 - Ensure that JWTs are securely stored and transmitted.
-- See the [OWASP JSON Web Tokens Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)
+- See the [OWASP JSON Web Tokens Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html).
 
 ## Tools
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -1,0 +1,71 @@
+# Testing JSON Web Tokens (JWTs)
+
+|ID          |
+|------------|
+|WSTG-SESS-010|
+
+## Summary
+
+- JWTs are cryptographically signed JSON tokens
+- Commonly used to authenticate on APIs
+- Lots of bad implementations and opportunities for things to go wrong
+
+## Test Objectives
+
+- Determine whether the JWTs expose sensitive information.
+- Determine whether the JWTs can be tampered with or modified.
+
+## How to Test
+
+### Overview
+
+- What a JWT is
+- Common usage scenarios
+
+### Analyse the Contents
+
+- JWTs are not usually encrypted
+- May expose sensitive information
+
+### Review Usage
+
+- How is JWT sent?
+- How is JWT stored?
+- Does JWT expire?
+- Can JWT be invalidated?
+
+### Signature Verification
+
+- Signature may not be verified at all (`jwt.decode()` vs `jwt.verify()`)
+- `none` or `NoNe` algorithms may be allowed
+
+### Weak HMAC Keys
+
+- HMAC uses a secret key
+- Convert JWT into crackable format
+- Try and crack key
+
+### HMAC vs RSA Confusion
+
+- Obtain public key
+    - Public key may be in `/.well-known/jwks.json`
+    - Obtain public key from TLS cert (shouldn't be re-used, but may be)
+- Use public key as a secret to calculate a HMAC
+
+## Related Test Cases
+
+TODO
+
+## Remediation
+
+TODO
+
+## Tools
+
+- [John the Ripper](https://github.com/openwall/john)
+- [jw2john](https://github.com/Sjord/jwtcrack)
+- [jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker)
+
+## References
+
+- [RFC 7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/README.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/README.md
@@ -17,3 +17,5 @@
 4.6.8 [Testing for Session Puzzling](08-Testing_for_Session_Puzzling.md)
 
 4.6.9 [Testing for Session Hijacking](09-Testing_for_Session_Hijacking.md)
+
+4.6.10 [Testing JSON Web Tokens](10-Testing_JSON_Web_Tokens.md)

--- a/document/README.md
+++ b/document/README.md
@@ -160,6 +160,8 @@
 
 #### 4.6.9 [Testing for Session Hijacking](4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking.md)
 
+#### 4.6.10 [Testing JSON Web Tokens](4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md)
+
 ### 4.7 [Input Validation Testing](4-Web_Application_Security_Testing/07-Input_Validation_Testing/README.md)
 
 #### 4.7.1 [Testing for Reflected Cross Site Scripting](4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md)


### PR DESCRIPTION
Initial skeleton for a JWT testing guide, as discussed in issue #696.

I know that there's some debate about whether JWTs fall under session management. I put this in that folder because it seemed the most logical place (in reality that's what most people use them for) - very happy to move it somewhere else if there's consensus that it should be in another section. Whichever folder it ends up in will be more appropriate that the section in the "Testing APIs" document it's currently in.

This is just a skeleton for now, so key questions are:

- Do the points seem sensible?
- Is the structure sensible?
- Is there anything missing?