### PR TITLE
Rewrite of default password testing guide

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -27,16 +27,16 @@ Once the software has been identified, try to find whether it uses default passw
 - Reviewing the manual or vendor documentation.
 - Checking common default password databases, such as [CIRT.net](https://cirt.net/passwords) or [SecLists Default Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials).
 - Inspecting the application source code (if available).
-- Installing the application of a virtual machine and inspecting it.
+- Installing the application on a virtual machine and inspecting it.
 - Inspecting the physical hardware for stickers (often present on network devices).
 
 If a default password can't be found, try common options such as:
 
-- "admin", "password", "12345" or other [common default passwords](https://github.com/nixawk/fuzzdb/blob/master/bruteforce/passwds/default_devices_users%2Bpasswords.txt).
+- "admin", "password", "12345", or other [common default passwords](https://github.com/nixawk/fuzzdb/blob/master/bruteforce/passwds/default_devices_users%2Bpasswords.txt).
 - An empty or blank password.
 - The serial number of MAC address of the device.
 
-If the username is unknown, there are various options for enumerating users, discussed in the [Testing for Account Enumeration](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) guide. Alternatively, try common options such as "admin", "root" or "system".
+If the username is unknown, there are various options for enumerating users, discussed in the [Testing for Account Enumeration](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) guide. Alternatively, try common options such as "admin", "root", or "system".
 
 ### Testing for Organisation Default Passwords
 
@@ -46,7 +46,7 @@ When staff within an organisation manually create passwords for new accounts, th
 - Organisation specific details, such as the organisation name or address.
 - Passwords that follow a simple pattern, such as "Monday123" if account is created on a Monday.
 
-These type so of passwords are often difficult to identify from a black-box perspective, unless they can successfully be guessed or brute-forced. However, they are easy to identify when performing grey-box or white-box testing.
+These types of passwords are often difficult to identify from a black-box perspective, unless they can successfully be guessed or brute-forced. However, they are easy to identify when performing grey-box or white-box testing.
 
 ### Testing for Application Generated Default Passwords
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -23,7 +23,7 @@ The first step to identifying default passwords is to identify the software that
 
 Once the software has been identified, try to find whether it uses default passwords, and if so, what they are. This should include:
 
-- Searching for "SOFTWARE default password".
+- Searching for "[SOFTWARE] default password".
 - Reviewing the manual or vendor documentation.
 - Checking common default password databases, such as [CIRT.net](https://cirt.net/passwords) or [SecLists Default Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials).
 - Inspecting the application source code (if available).

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -34,7 +34,7 @@ If a default password can't be found, try common options such as:
 
 - "admin", "password", "12345", or other [common default passwords](https://github.com/nixawk/fuzzdb/blob/master/bruteforce/passwds/default_devices_users%2Bpasswords.txt).
 - An empty or blank password.
-- The serial number of MAC address of the device.
+- The serial number or MAC address of the device.
 
 If the username is unknown, there are various options for enumerating users, discussed in the [Testing for Account Enumeration](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) guide. Alternatively, try common options such as "admin", "root", or "system".
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -38,30 +38,28 @@ If a default password can't be found, try common options such as:
 
 If the username is unknown, there are various options for enumerating users, discussed in the [Testing for Account Enumeration](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) guide. Alternatively, try common options such as "admin", "root" or "system".
 
-### Testing for Default Password of New Accounts
+### Testing for Organisation Default Passwords
 
-It can also occur that when a new account is created in an application the account is assigned a default password. This password could have some standard characteristics making it predictable. If the user does not change it on first usage (this often happens if the user is not forced to change it) or if the user has not yet logged on to the application, this can lead an attacker to gain unauthorized access to the application.
+When staff within an organisation manually create passwords for new accounts, they may do so in a predictable way. This can often be:
 
-The advice given before about a possible lockout policy and verbose error messages are also applicable here when testing for default passwords.
+- A single common password such as "Password1".
+- Organisation specific details, such as the the organisation name or address.
+- Passwords that follow a simple pattern, such as "Monday123" if account is created on a Monday.
 
-The following steps can be applied to test for these types of default credentials:
+These type so of passwords are often difficult to identify from a black-box perspective, unless they can successfully be guessed or brute-forced. However, they are easy to identify when performing grey-box or white-box testing.
 
-- Looking at the User Registration page may help to determine the expected format and minimum or maximum length of the application usernames and passwords. If a user registration page does not exist, determine if the organization uses a standard naming convention for usernames such as their email address or the name before the `@` in the email.
-- Try to extrapolate from the application how usernames are generated. For example, can a user choose their own username or does the system generate an account name for the user based on some personal information or by using a predictable sequence? If the application does generate the account names in a predictable sequence, such as `user7811`, try fuzzing all possible accounts recursively. If you can identify a different response from the application when using a valid username and a wrong password, then you can try a brute force attack on the valid username (or quickly try any of the identified common passwords above or in the reference section).
-- Try to determine if the system generated password is predictable. To do this, create many new accounts quickly after one another so that you can compare and determine if the passwords are predictable. If predictable, try to correlate these with the usernames, or any enumerated accounts, and use them as a basis for a brute force attack.
-- If you have identified the correct naming convention for the user name, try to "brute force" passwords with some common predictable sequence like for example dates of birth.
-- Attempt using all the above usernames with blank passwords or using the username also as password value.
+### Testing for Application Generated Default Passwords
 
-#### Gray-Box Testing
+If the application automatically generates passwords for new user accounts, these may also be predictable. In order to test these, create multiple accounts on the application and compare the passwords that are given for them.
 
-The following steps rely on an entirely gray-box approach. If only some of this information is available to you, refer to black-box testing to fill the gaps.
+The passwords may be based on:
 
-- Talk to the IT personnel to determine which passwords they use for administrative access and how administration of the application is undertaken.
-- Ask IT personnel if default passwords are changed and if default user accounts are disabled.
-- Examine the user database for default credentials as described in the black-box testing section. Also check for empty password fields.
-- Examine the code for hard coded usernames and passwords.
-- Check for configuration files that contain usernames and passwords.
-- Examine the password policy and, if the application generates its own passwords for new users, check the policy in use for this procedure.
+- A single static string shared between accounts.
+- A hashed or obfuscated part of the account details, such as `md5($username)`.
+- A time-based algorithm.
+- A weak pseudo-random number generator (PRNG).
+
+This type of issue of often difficult to identify from a black-box perspective.
 
 ## Tools
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -6,49 +6,37 @@
 
 ## Summary
 
-Nowadays web applications often make use of popular Open Source or commercial software that can be installed on servers with minimal configuration or customization by the server administrator. Moreover, a lot of hardware appliances (i.e. network routers and database servers) offer web-based configuration or administrative interfaces.
+Many web applications and hardware devices have default passwords for the built-in administrative account. Although in some cases these can be randomly generated, they are often static, meaning that they can be easily guessed or obtained by an attacker.
 
-Often these applications, once installed, are not properly configured and the default credentials provided for initial authentication and configuration are never changed. These default credentials are well known by penetration testers and, unfortunately, also by malicious attackers, who can use them to gain access to various types of applications.
-
-Furthermore, in many situations, when a new account is created on an application, a default password (with some standard characteristics) is generated. If this password is predictable and the user does not change it on the first access, this can lead to an attacker gaining unauthorized access to the application.
-
-The root cause of this problem can be identified as:
-
-- Inexperienced IT personnel, who are unaware of the importance of changing default passwords on installed infrastructure components, or leave the password as default for "ease of maintenance".
-- Programmers who leave back doors to easily access and test their application and later forget to remove them.
-- Applications with built-in non-removable default accounts with a preset username and password.
-- Applications that do not force the user to change the default credentials after the first log in.
+Additionally, when new users are created on the applications, these may have pre-defined passwords set. These could either be generated automatically by the application, or manually created by staff. In both cases, if they are not generated in a secure manner, the passwords may be possible for an attacker to guess.
 
 ## Test Objectives
 
-- Enumerate the applications for default credentials and validate if they still exist.
-- Review and assess new user accounts and if they are created with any defaults or identifiable patterns.
+- Determine whether the application has any user accounts with default passwords.
+- Review whether new user accounts are created with weak or predictable passwords.
 
 ## How to Test
 
-### Testing for Default Credentials of Common Applications
+### Testing for Vendor Default Credentials
 
-In black-box testing the tester knows nothing about the application and its underlying infrastructure. In reality this is often not true, and some information about the application is known. We suppose that you have identified, through the use of the techniques described in this Testing Guide under the chapter [Information Gathering](../01-Information_Gathering/README.md), at least one or more common applications that may contain accessible administrative interfaces.
+The first step to identifying default passwords is to identify the software that is in use. This is covered in detail in the [Information Gathering](../01-Information_Gathering/README.md) section of the guide.
 
-When you have identified an application interface, for example a Cisco router web interface or a WebLogic administrator portal, check that the known usernames and passwords for these devices do not result in successful authentication. To do this you can consult the manufacturer’s documentation or, in a much simpler way, you can find common credentials using a search engine or by using one of the sites or tools listed in the Reference section.
+Once the software has been identified, try to find whether it uses default passwords, and if so, what they are. This should include:
 
-When facing applications where we do not have a list of default and common user accounts (for example due to the fact that the application is not wide spread) we can attempt to guess valid default credentials. Note that the application being tested may have an account lockout policy enabled, and multiple password guess attempts with a known username may cause the account to be locked. If it is possible to lock the administrator account, it may be troublesome for the system administrator to reset it.
+- Searching for "SOFTWARE default password".
+- Reviewing the manual or vendor documentation.
+- Checking common default password databases, such as [CIRT.net](https://cirt.net/passwords).
+- Inspecting the application source code (if available).
+- Installing the application of a virtual machine and inspecting it.
+- Inspecting the physical hardware for stickers (often present on network devices).
 
-Many applications have verbose error messages that inform the site users as to the validity of entered usernames. This information will be helpful when testing for default or guessable user accounts. Such functionality can be found, for example, on the log in page, password reset and forgotten password page, and sign up page. Once you have found a default username you could also start guessing passwords for this account.
+If a default password can't be found, try common options such as:
 
-More information about this procedure can be found in the following sections:
+- "admin", "password", "12345" or other [common default passwords](https://github.com/nixawk/fuzzdb/blob/master/bruteforce/passwds/default_devices_users%2Bpasswords.txt)
+- An empty or blank password.
+- The serial number of MAC address of the device.
 
-- [Testing for User Enumeration and Guessable User Account](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md)
-- [Testing for Weak password policy](07-Testing_for_Weak_Password_Policy.md).
-
-Since these types of default credentials are often bound to administrative accounts you can proceed in this manner:
-
-- Try the following usernames - "admin", "administrator", "root", "system", "guest", "operator", or "super". These are popular among system administrators and are often used. Additionally you could try "qa", "test", "test1", "testing" and similar names. Attempt any combination of the above in both the username and the password fields. If the application is vulnerable to username enumeration, and you manage to successfully identify any of the above usernames, attempt passwords in a similar manner. In addition try an empty password or one of the following "password", "pass123", "password123", "admin", or "guest" with the above accounts or any other enumerated accounts. Further permutations of the above can also be attempted. If these passwords fail, it may be worth using a common username and password list and attempting multiple requests against the application. This can, of course, be scripted to save time.
-- Application administrative users are often named after the application or organization. This means if you are testing an application named "Obscurity", try using obscurity/obscurity or any other similar combination as the username and password.
-- When performing a test for a customer, attempt using names of contacts you have received as usernames with any common passwords. Customer email addresses mail reveal the user accounts naming convention: if employee "John Doe" has the email address `jdoe@example.com`, you can try to find the names of system administrators on social media and guess their username by applying the same naming convention to their name.
-- Attempt using all the above usernames with blank passwords.
-- Review the page source and JavaScript either through a proxy or by viewing the source. Look for any references to users and passwords in the source. For example `If username='admin' then starturl=/admin.asp else /index.asp` (for a successful log in versus a failed log in). Also, if you have a valid account, then log in and view every request and response for a valid log in versus an invalid log in, such as additional hidden parameters, interesting GET request (login=yes), etc.
-- Look for account names and passwords written in comments in the source code. Also look in backup directories for source code (or backups of source code) that may contain interesting comments and code.
+If the username is unknown, there are various options for enumerating users, discussed in the [Testing for Account Enumeration](../03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md) guide. Alternatively, try common options such as "admin", "root" or "system".
 
 ### Testing for Default Password of New Accounts
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -8,7 +8,7 @@
 
 Many web applications and hardware devices have default passwords for the built-in administrative account. Although in some cases these can be randomly generated, they are often static, meaning that they can be easily guessed or obtained by an attacker.
 
-Additionally, when new users are created on the applications, these may have pre-defined passwords set. These could either be generated automatically by the application, or manually created by staff. In both cases, if they are not generated in a secure manner, the passwords may be possible for an attacker to guess.
+Additionally, when new users are created on the applications, these may have predefined passwords set. These could either be generated automatically by the application, or manually created by staff. In both cases, if they are not generated in a secure manner, the passwords may be possible for an attacker to guess.
 
 ## Test Objectives
 

--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -25,14 +25,14 @@ Once the software has been identified, try to find whether it uses default passw
 
 - Searching for "SOFTWARE default password".
 - Reviewing the manual or vendor documentation.
-- Checking common default password databases, such as [CIRT.net](https://cirt.net/passwords).
+- Checking common default password databases, such as [CIRT.net](https://cirt.net/passwords) or [SecLists Default Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials).
 - Inspecting the application source code (if available).
 - Installing the application of a virtual machine and inspecting it.
 - Inspecting the physical hardware for stickers (often present on network devices).
 
 If a default password can't be found, try common options such as:
 
-- "admin", "password", "12345" or other [common default passwords](https://github.com/nixawk/fuzzdb/blob/master/bruteforce/passwds/default_devices_users%2Bpasswords.txt)
+- "admin", "password", "12345" or other [common default passwords](https://github.com/nixawk/fuzzdb/blob/master/bruteforce/passwds/default_devices_users%2Bpasswords.txt).
 - An empty or blank password.
 - The serial number of MAC address of the device.
 
@@ -43,14 +43,14 @@ If the username is unknown, there are various options for enumerating users, dis
 When staff within an organisation manually create passwords for new accounts, they may do so in a predictable way. This can often be:
 
 - A single common password such as "Password1".
-- Organisation specific details, such as the the organisation name or address.
+- Organisation specific details, such as the organisation name or address.
 - Passwords that follow a simple pattern, such as "Monday123" if account is created on a Monday.
 
 These type so of passwords are often difficult to identify from a black-box perspective, unless they can successfully be guessed or brute-forced. However, they are easy to identify when performing grey-box or white-box testing.
 
 ### Testing for Application Generated Default Passwords
 
-If the application automatically generates passwords for new user accounts, these may also be predictable. In order to test these, create multiple accounts on the application and compare the passwords that are given for them.
+If the application automatically generates passwords for new user accounts, these may also be predictable. In order to test these, create multiple accounts on the application with similar details at the same time, and compare the passwords that are given for them.
 
 The passwords may be based on:
 
@@ -63,10 +63,11 @@ This type of issue of often difficult to identify from a black-box perspective.
 
 ## Tools
 
-- [Burp Intruder](https://portswigger.net/burp)
+- [Burp Intruder](https://portswigger.net/burp/documentation/desktop/tools/intruder)
 - [THC Hydra](https://github.com/vanhauser-thc/thc-hydra)
 - [Nikto 2](https://www.cirt.net/nikto2)
 
 ## References
 
 - [CIRT](https://cirt.net/passwords)
+- [SecLists Default Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials)


### PR DESCRIPTION
As per discussion in #564, this guide had a lot of unnecessary fluff and padding.