### PR TITLE
chore: www publishing workflows now use static feature branch names

### DIFF
--- a/.github/workflows/www_latest_update.yml
+++ b/.github/workflows/www_latest_update.yml
@@ -34,7 +34,7 @@ jobs:
         cd wstg
         echo "WSTG_BASE=$(pwd)" >> $GITHUB_ENV
         echo "SRC_BASE="OWASP/wstg@"$(git log -1 --format=format:%h)" >> $GITHUB_ENV
-        echo "BRANCH_STAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_ENV
+        echo "BRANCH=latest-update" >> $GITHUB_ENV
         echo "SHORT_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
         cd ../www-project-web-security-testing-guide
         echo "WWW_BASE=$(pwd)" >> $GITHUB_ENV
@@ -43,7 +43,7 @@ jobs:
         cd $WWW_BASE
         git remote add origin https://github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         # Checkout what will be the new feature branch
-        git checkout -b $BRANCH_STAMP
+        git checkout -b $BRANCH
         # Remove old 'latest' content
         rm -rf latest
         mkdir latest
@@ -84,5 +84,5 @@ jobs:
         git remote set-url origin https://$GITHUB_USER:${{ secrets.wstg_deploy_token }}@github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         git add .
         git commit -m "Publish Latest $SHORT_DATE" -m "Updates based on $SRC_BASE"
-        git push --set-upstream origin $BRANCH_STAMP
+        git push --set-upstream origin $BRANCH --force
         hub pull-request --no-edit

--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -38,7 +38,7 @@ jobs:
         cd wstg
         echo "WSTG_BASE=$(pwd)" >> $GITHUB_ENV
         echo "SRC_BASE="OWASP/wstg@"$(git log -1 --format=format:%h)" >> $GITHUB_ENV
-        echo "BRANCH_STAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_ENV
+        echo "BRANCH=stable-update" >> $GITHUB_ENV
         echo "SHORT_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
         cd ../www-project-web-security-testing-guide
         echo "WWW_BASE=$(pwd)" >> $GITHUB_ENV
@@ -49,7 +49,7 @@ jobs:
         cd $WWW_BASE
         git remote add origin https://github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         # Checkout what will be the new feature branch
-        git checkout -b $BRANCH_STAMP
+        git checkout -b $BRANCH
         # Remove old 'stable' content
         rm -rf stable
         mkdir stable
@@ -125,5 +125,5 @@ jobs:
         git remote set-url origin https://$GITHUB_USER:${{ secrets.wstg_deploy_token }}@github.com/$GITHUB_USER/www-project-web-security-testing-guide.git
         git add .
         git commit -m "Publish Stable and $VERSION_TAG - $SHORT_DATE" -m "Updates based on $SRC_BASE $VERSION_TAG"
-        git push --set-upstream origin $BRANCH_STAMP
+        git push --set-upstream origin $BRANCH --force
         hub pull-request --no-edit


### PR DESCRIPTION
Use static feature branch names vs. datestamp so that wstgbot doesn't endup with a ton of branches (or hitting some GitHub limit).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>