### PR TITLE
improve: GitHub Action Workflows no longer include file ext on links

### DIFF
--- a/.github/workflows/www_latest_update.yml
+++ b/.github/workflows/www_latest_update.yml
@@ -72,8 +72,8 @@ jobs:
         sed -i '1d' README.md
         # Find the anchor links (URL fragments) and lowercase them
         sed -i -E 's/\.md#(.*)$/\.md#\L\1/g' README.md
-        # Switch .md references to .html
-        sed -i 's/.md/.html/g' README.md
+        # Switch .md references to no extension
+        sed -i 's/.md//g' README.md
         # Add the leadin and add the generated yaml
         cat prepend.nav > latest.yaml && cat README.md >> latest.yaml
         # Copy the navigation yaml to _data

--- a/.github/workflows/www_stable_update.yml
+++ b/.github/workflows/www_stable_update.yml
@@ -82,8 +82,8 @@ jobs:
         sed -i '1d' README.md
         # Find the anchor links (URL fragments) and lowercase them
         sed -i -E 's/\.md#(.*)$/\.md#\L\1/g' README.md
-        # Switch .md references to .html
-        sed -i 's/.md/.html/g' README.md
+        # Switch .md references to no extension
+        sed -i 's/.md//g' README.md
         # Add the leadin and add the generated yaml
         cat prepend.nav > stable.yaml && cat README.md >> stable.yaml
         # Copy the navigation yaml to _data
@@ -113,8 +113,8 @@ jobs:
         sed -i '1d' README.md
         # Find the anchor links (URL fragments) and lowercase them
         sed -i -E 's/\.md#(.*)$/\.md#\L\1/g' README.md
-        # Switch .md references to .html
-        sed -i 's/.md/.html/g' README.md
+        # Switch .md references to no extension
+        sed -i 's/.md//g' README.md
         # Add the leadin and add the generated yaml
         cat prepend.nav > $VERSION_PATH.yaml && cat README.md >> $VERSION_PATH.yaml
         # Copy the navigation yaml to _data


### PR DESCRIPTION
Instead of switching .md to .html just drop the extension entirely.

GitHub pages seems to serve .md, .html, and no extension normally so even if someone happens to have linked content with .html then it'll be fine.

Changed both the "latest" job and the "stable" job, existing content for v4.1 and v4.2 will continue to have the .html extensions, but that's fine.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>