### PR TITLE
Add steps for making arbitrary HTTP requests in Chrome

### DIFF
--- a/document/6-Appendix/F-Leveraging_Dev_Tools.md
+++ b/document/6-Appendix/F-Leveraging_Dev_Tools.md
@@ -82,6 +82,14 @@ Later click on the garbage can `Delete` button to the right of the `general.user
 4. Make desired modifications and click on the `Send` button.
 5. Right-click on the modified request and select `Open in New Tab`.
 
+### Google Chrome
+
+1. Select the `Network` tab.
+2. Perform any action in the web application.
+3. Right-click on the HTTP request from the list and select `Copy > Copy as fetch`.
+4. Paste the provided JavaScript code into the `Console` tab.
+5. Make any required modifications, and then hit enter to send the request.
+
 ## Cookie Editing
 
 ### Related Testing


### PR DESCRIPTION
Adding in some steps to make arbitrary requests in Chrome. There were already steps to do this in Firefox.