### PR TITLE
fix: link check exclusions now include github

### DIFF
--- a/.github/configs/markdown-link-check-config.json
+++ b/.github/configs/markdown-link-check-config.json
@@ -1,5 +1,5 @@
 {
-        "ignorePatterns": [
+    "ignorePatterns": [
         {
             "pattern": "^\/"
         },

--- a/.github/configs/markdown-link-check-config.json
+++ b/.github/configs/markdown-link-check-config.json
@@ -1,23 +1,26 @@
 {
-    "ignorePatterns": [
-    {
-        "pattern": "^\/"
-    },
-    {
-        "pattern": "^https://www.nstalker.com"
-    },
-    {
-        "pattern": "^https://www.kali.org"
-    },
-    {
-        "pattern": "^https://.*.linkedin.com"
-    },
-    {
-        "pattern": "^https://www.shodan.io"
-    },
-    {
-        "pattern": "^https://developer.android.com"
-    }
+        "ignorePatterns": [
+        {
+            "pattern": "^\/"
+        },
+        {
+            "pattern": "^https://www.nstalker.com"
+        },
+        {
+            "pattern": "^https://www.kali.org"
+        },
+        {
+            "pattern": "^https://.*.linkedin.com"
+        },
+        {
+            "pattern": "^https://www.shodan.io"
+        },
+        {
+            "pattern": "^https://developer.android.com"
+        },
+        {
+            "pattern": "^https://github.com"
+        }
     ],
     "httpHeaders": [{
         "urls": [


### PR DESCRIPTION
Per recent PRs like: https://github.com/OWASP/wstg/pull/776

I both added github and fixed indentation of the whole block, only the last entry is actually new.