### PR TITLE
improve: markdownlint-cli dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "markdownlint-cli": "^0.19.0"
+    "markdownlint-cli": "^0.28.1"
   },
   "scripts": {
     "pdfgen": "bash ./.github/pdf/scripts/make-pdf.sh",


### PR DESCRIPTION
- [ ] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- markdownlint-cli latest version seems to be 0.28.1. Per: markdownlint-cli

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>