### PR TITLE
Update 04-Testing_for_Exposed_Session_Variables.md

### DIFF
--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables.md
@@ -75,7 +75,7 @@ All interaction between the Client and Application should be tested at least aga
 
 - How are Session IDs transferred? e.g., GET, POST, Form Field (including hidden fields)
 - Are Session IDs always sent over encrypted transport by default?
-- Is it possible to manipulate the application to send Session IDs unencrypted? e.g., by changing HTTP to HTTPS?
+- Is it possible to manipulate the application to send Session IDs unencrypted? e.g., by changing HTTPS to HTTP?
 - What cache-control directives are applied to requests/responses passing Session IDs?
 - Are these directives always present? If not, where are the exceptions?
 - Are GET requests incorporating the Session ID used?


### PR DESCRIPTION
Line 78, switched 'HTTPS and HTTP', otherwise session IDs would be sent over an encrypted channel.

This PR covers a new issue.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Line 78, switched 'HTTPS and HTTP'

Thank you for your contribution!