### PR TITLE
feat: WSTG-INFO-05: Add leaks via redirect with body content

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-It is very common, and even recommended, for programmers to include detailed comments and metadata on their source code. However, comments and metadata included into the HTML code might reveal internal information that should not be available to potential attackers. Comments and metadata review should be done in order to determine if any information is being leaked.
+It is very common, and even recommended, for programmers to include detailed comments and metadata on their source code. However, comments and metadata included into the HTML code might reveal internal information that should not be available to potential attackers. Comments and metadata review should be done in order to determine if any information is being leaked. Additionally some applications may leak information in the body of redirect responses.
 
 For modern web apps, the use of client-Side JavaScript for the front-end is becoming more popular. Popular front-end construction technologies use client-side JavaScript like ReactJS, AngularJS, or Vue.  Similar to the comments and metadata in HTML code, many programmers also hardcode sensitive information in JavaScript variables on the front-end. Sensitive information can include (but is not limited to): Private API Keys (*e.g.* an unrestricted Google Map API Key), internal IP addresses, sensitive routes (*e.g.* route to hidden admin pages or functionality), or even credentials. This sensitive information can be leaked from such front-end JavaScript code. A review should be done in order to determine if any sensitive information leaked which could be used by attackers for abuse.
 
@@ -14,13 +14,13 @@ For large web applications, performance issues are a big concern to programmers.
 
 ## Test Objectives
 
-- Review webpage comments and metadata to find any information leakage.
+- Review webpage comments, metadata, and redirect bodies to find any information leakage.
 - Gather JavaScript files and review the JS code to better understand the application and to find any information leakage.
 - Identify if source map files or other front-end debug files exist.
 
 ## How to Test
 
-### Review webpage comments and metadata
+### Review Webpage Comments and Metadata
 
 HTML comments are often used by the developers to include debugging information about the application. Sometimes, they forget about the comments and they leave them in production environments. Testers should look for HTML comments which start with `<!--`.
 
@@ -127,8 +127,6 @@ In some cases, testers may find sensitive routes from JavaScript code, such as l
 
 Source map files will usually be loaded when DevTools open. Testers can also find source map files by adding the ".map" extension after the extension of each external JavaScript file. For example, if a tester sees a `/static/js/main.chunk.js` file, they can then check for its source map file by visiting `/static/js/main.chunk.js.map`.
 
-#### Black-Box Testing
-
 Check source map files for any sensitive information that can help the attacker gain more insight about the application. For example:
 
 ```json
@@ -148,12 +146,19 @@ Check source map files for any sensitive information that can help the attacker 
 
 When websites load source map files, the front-end source code will become readable and easier to debug.
 
+### Identify Redirect Responses which Leak Information
+
+Although redirect responses are not generally expected to contain any significant web content there is no assurance that they cannot contain content. So, while series 300 (redirect) responses often contain "redirecting to `https://example.com/`" type content they may also leak content. 
+
+Consider a situation in which a redirect response is the result of an authentication or authorization check, if that check fails the server may respond redirecting the user back to a "safe" or "default" page, yet the redirect response itself may still contain content which isn't shown in the browser but is indeed transmitted to the client. This can be seen either leveraging browser developer tools or via a personal proxy (such as ZAP, Burp, Fiddler, or Charles).
+
 ## Tools
 
 - [Wget](https://www.gnu.org/software/wget/wget.html)
 - Browser "view source" function
 - Eyeballs
 - [Curl](https://curl.haxx.se/)
+- [Zaproxy](https://www.zaproxy.org)
 - [Burp Suite](https://portswigger.net/burp)
 - [Waybackurls](https://github.com/tomnomnom/waybackurls)
 - [Google Maps API Scanner](https://github.com/ozguralp/gmapsapiscanner/)
@@ -161,6 +166,7 @@ When websites load source map files, the front-end source code will become reada
 ## References
 
 - [KeyHacks](https://github.com/streaak/keyhacks)
+- [RingZer0 Online CTF](https://ringzer0ctf.com/challenges/104) - Challenge 104 "Admin Panel".
 
 ### Whitepapers
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage.md
@@ -148,7 +148,7 @@ When websites load source map files, the front-end source code will become reada
 
 ### Identify Redirect Responses which Leak Information
 
-Although redirect responses are not generally expected to contain any significant web content there is no assurance that they cannot contain content. So, while series 300 (redirect) responses often contain "redirecting to `https://example.com/`" type content they may also leak content. 
+Although redirect responses are not generally expected to contain any significant web content there is no assurance that they cannot contain content. So, while series 300 (redirect) responses often contain "redirecting to `https://example.com/`" type content they may also leak content.
 
 Consider a situation in which a redirect response is the result of an authentication or authorization check, if that check fails the server may respond redirecting the user back to a "safe" or "default" page, yet the redirect response itself may still contain content which isn't shown in the browser but is indeed transmitted to the client. This can be seen either leveraging browser developer tools or via a personal proxy (such as ZAP, Burp, Fiddler, or Charles).
 


### PR DESCRIPTION
Fixes OWASP/wstg#810

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Revised lead-in and test objectives.
- Fixed title caps on one sub-heading.
- Added new L3 section with relevant content.
- Deleted one un-necessary L4 heading.
- Add ZAP to tools.
- Add reference to RingZer0 CTF challenge 104 which is one manifestation of the issue.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>