### PR TITLE
Prevent code injection

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -8,6 +8,10 @@ on:
     - '!translations/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   link-check:
     runs-on: ubuntu-latest
@@ -50,17 +54,11 @@ jobs:
         echo $(cat log)
         echo $(cat err)
     - name: Show broken links
-      id: brokenlinks
       if: failure()
       run: |
         cat log | awk -v RS="FILE:" 'match($0, /(\S*\.md).*\[✖\].*(\d*\slinks\schecked\.)(.*)/, arr ) { print "FILE:"arr[1] arr[3] > "brokenlinks.txt"}'
         cat brokenlinks.txt
         rm -f err log
-        LINKS=`cat brokenlinks.txt`
-        LINKS="${LINKS//'%'/'%25'}"
-        LINKS="${LINKS//$'\n'/'%0A'}"
-        LINKS="${LINKS//$'\r'/'%0D'}"
-        echo ::set-output name=LINKS::**Following links are broken:** %0A$LINKS
     - name: Upload list of broken links
       if: failure()
       uses: actions/upload-artifact@v1
@@ -73,9 +71,12 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
+          const fs = require("fs");
+          const brokenLinksPath = `${process.env.GITHUB_WORKSPACE}/brokenlinks.txt`;
+          const brokenLinksString = fs.readFileSync(brokenLinksPath).toString().trimEnd();
           github.issues.createComment({
             issue_number: ${{ github.event.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `${{ steps.brokenlinks.outputs.LINKS }}`
+            body: `**The following links are broken:** \n${brokenLinksString}`
           })

--- a/.github/workflows/md-lint-check.yml
+++ b/.github/workflows/md-lint-check.yml
@@ -7,6 +7,11 @@ on:
     paths:
     - '**.md'
     - '!.github/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -25,16 +30,10 @@ jobs:
     - name: Run linter
       run: markdownlint . --config .github/configs/.markdownlint.json --ignore node_modules --ignore .github &> lint.txt
     - name: Show Linting Issues
-      id: lint
       if: failure()
       run: |
         cat lint.txt
         sed -i 's/```/triple-backtick/g' lint.txt
-        ISSUES=$(cat lint.txt)
-        ISSUES="${ISSUES//'%'/'%25'}"
-        ISSUES="${ISSUES//$'\n'/'%0A'}"
-        ISSUES="${ISSUES//$'\r'/'%0D'}"
-        echo ::set-output name=ISSUES::**The following issues were identified:** %0A$ISSUES
     - name: Attach Linting Issues
       if: failure()
       uses: actions/upload-artifact@v1
@@ -47,10 +46,13 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
+          const fs = require("fs");
+          const lintPath = `${process.env.GITHUB_WORKSPACE}/lint.txt`;
+          const lintString = fs.readFileSync(lintPath).toString().trimEnd();
           github.issues.createComment({
             issue_number: ${{ github.event.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `${{ steps.lint.outputs.ISSUES }}`
+            body: `**The following issues were identified:** \n${lintString}`
           })
 

--- a/.github/workflows/md-textlint-check.yml
+++ b/.github/workflows/md-textlint-check.yml
@@ -9,6 +9,10 @@ on:
     - '!.github/**'
     - '!translations/**'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   textlint:
     runs-on: ubuntu-latest
@@ -42,30 +46,28 @@ jobs:
         for FILE in $FILES; do echo $FILE | grep -v \.github | grep -v translations && textlint --config .github/configs/.textlintrc --fix --rule terminology $FILE | tee -a log.txt; done
         if grep -q  'Incorrect usage' log.txt ; then exit 1 ; else echo -e \"No terminology issues found.\"; fi
     - name: Show Mistakes
-      id: mistakes
       if: failure()
       run: |
         cat log.txt
-        MISTAKES=$(cat log.txt|grep -v '✔ Fixed'|tr '✔' '✖')
-        MISTAKES="${MISTAKES//'%'/'%25'}"
-        MISTAKES="${MISTAKES//$'\n'/'%0A'}"
-        MISTAKES="${MISTAKES//$'\r'/'%0D'}"
-        echo ::set-output name=MISTAKES::**The following mistakes were identified:** %0A$MISTAKES
+        cat log.txt | grep -v '✔ Fixed' | tr '✔' '✖' >mistakes.txt
     - name: Attach Mistakes
       if: failure()
       uses: actions/upload-artifact@v1
       with:
         name: Terminology Mistakes
-        path: log.txt
+        path: mistakes.txt
     - name: Comment Mistakes
       if: failure()
       uses: actions/github-script@v2
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
+          const fs = require("fs");
+          const mistakesPath = `${process.env.GITHUB_WORKSPACE}/mistakes.txt`;
+          const mistakesString = fs.readFileSync(mistakesPath).toString().trimEnd();
           github.issues.createComment({
             issue_number: ${{ github.event.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `${{ steps.mistakes.outputs.MISTAKES }}`
+            body: `**The following mistakes were identified:** \n${mistakesString}`
           })


### PR DESCRIPTION
Fixes #814.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Prevents code injection in GitHub Actions workflows with write access
- Minimizes permissions used, limiting impact of any vulnerabilities found in the future
- Also fixes the issue that caused #578, but I left the "triple-backtick" replacement as it avoids issues when the comment gets parsed as markdown. It might be worth switching to the [comment format used by OWASP-VWAD](https://github.com/OWASP/OWASP-VWAD/blob/4037e00777b18d10fd85faebba83e9c349e47524/.github/workflows/validate.yml#L58) to fix that completely.