### PR TITLE
line 29 : classify "UAT, test, etc" as non-public

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
@@ -26,7 +26,7 @@ Use a search engine to search for potentially sensitive information. This may in
 - usernames, passwords, and private keys;
 - third-party, or cloud service configuration files;
 - revealing error message content; and
-- development, test, User Acceptance Testing (UAT), and staging versions of sites.
+- non-public applications (development, test, User Acceptance Testing (UAT), and staging versions of sites).
 
 ### Search Engines
 


### PR DESCRIPTION
On line 29, would you classify 
> ... (development, test, User Acceptance Testing (UAT), and staging versions of sites).

as [non-public](https://pentest-tools.com/information-gathering/find-subdomains-of-domain) sites?

When you click on the link above, look under **Technical Details** to better understand my question?

Take care.