### PR TITLE
Remove an offending line against HTTP methods marking them as unsafe

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -19,8 +19,6 @@ HTTP offers a number of methods that can be used to perform actions on the web s
 - [`OPTIONS`](https://tools.ietf.org/html/rfc7231#section-4.3.7)
 - [`TRACE`](https://tools.ietf.org/html/rfc7231#section-4.3.8)
 
-However, most web applications only need to respond to GET and POST requests, receiving user data in the URL query string or appended to the request respectively. The standard `<a href=""></a>` style links as well as forms defined without a method trigger a GET request; form data submitted via `<form method='POST'></form>` trigger POST requests. JavaScript and AJAX calls may send methods other than GET and POST but should usually not need to do that. Since the other methods are so rarely used, many developers do not know, or fail to take into consideration, how the web server or application framework's implementation of these methods impact the security features of the application.
-
 ## Test Objectives
 
 - Enumerate supported HTTP methods.


### PR DESCRIPTION
This PR covers a slack [thread](https://owasp.slack.com/archives/C04T40NND/p1644312776314039) issue that was brought up.

A line instills a false sense of security mentioning that the only HTTP methods that should be allowed are GET and POST.

I removed the whole paragraph as it didn't add anything of importance to the document.