### PR TITLE
Update HTTP method testing.

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -15,7 +15,7 @@ HTTP offers a number of methods (or verbs) that can be used to perform actions o
 | [`GET`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1) | Request a file. | Request an object.|
 | [`HEAD`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.2) | Request a file, but only return the HTTP headers. | |
 | [`POST`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.3) | Submit data. | |
-| [`PUT`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4) | Upload a file. | Create an object. 
+| [`PUT`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4) | Upload a file. | Create an object. |
 | [`DELETE`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.5) | Delete a file | Delete an object. |
 | [`CONNECT`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6) | Establish a connection to another system. | |
 | [`OPTIONS`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7) | List supported HTTP methods. | Perform a [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) request.
@@ -38,6 +38,7 @@ To perform this test, the tester needs some way to identify which HTTP methods a
 OPTIONS / HTTP/1.1
 Host: example.org
 ```
+
 The server should then response with a list of supported methods:
 
 ```http

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -46,9 +46,9 @@ Allow: OPTIONS, GET, HEAD, POST
 
 However, some servers may not respond to `OPTIONS` requests, or may return inaccurate information. Additionally, servers may support different methods for different paths - so just because a method is not supported for the root `/` directory, this doesn't necessarily mean that it won't be supported elsewhere.
 
-An alternatively way to test for supported methods is to simply make a request with that method type, and examine the server response. If the method is not permitted, the server should return a `405 Method Not Allowed` status.
+An alternative way to test for supported methods is to simply make a request with that method type, and examine the server response. If the method is not permitted, the server should return a `405 Method Not Allowed` status.
 
-Note that some servers treat unknown methods as equivalent to `GET`, so they may response to arbitrary methods, such as the request shown below. This can occasionally be useful to evade a web application firewall, or any other filtering that blocks specific methods.
+Note that some servers treat unknown methods as equivalent to `GET`, so they may respond to arbitrary methods, such as the request shown below. This can occasionally be useful to evade a web application firewall, or any other filtering that blocks specific methods.
 
 ```http
 FOO / HTTP/1.1
@@ -61,7 +61,7 @@ Requests with arbitrary methods can also be made using cURL with the `-X` option
 curl -X FOO https://example.org
 ```
 
-There are also a variety of automated tools that can attempt to determine supported methods, such as the [`http-methods`](https://nmap.org/nsedoc/scripts/http-methods.html) Nmap script. However, these tools may not test for dangerous methods (such as `PUT` or `DELETE`), or may unintentionally cause changes to the web server if this methods are supported. As such, they should be used with care.
+There are also a variety of automated tools that can attempt to determine supported methods, such as the [`http-methods`](https://nmap.org/nsedoc/scripts/http-methods.html) Nmap script. However, these tools may not test for dangerous methods (such as `PUT` or `DELETE`), or may unintentionally cause changes to the web server if these methods are supported. As such, they should be used with care.
 
 ### PUT and DELETE
 
@@ -85,7 +85,7 @@ Similar requests can also be made with cURL:
 curl https://example.org --upload-file test.html
 ```
 
-This allows an attacker to upload arbitrary files to the webserver, which could potential result in a full system compromise if they are allowed to upload executable code such as PHP files. However, this configuration is extremely rare, and is unlikely to be seen on any modern systems.
+This allows an attacker to upload arbitrary files to the webserver, which could potentially result in a full system compromise if they are allowed to upload executable code such as PHP files. However, this configuration is extremely rare, and is unlikely to be seen on any modern systems.
 
 Similarly, the `DELETE` method can be used to delete files from the webserver. Note that this is a **destructive action**, so care should be taken when testing this method.
 
@@ -102,7 +102,7 @@ curl http://example.org/test.html -X DELETE
 
 #### RESTful APIs
 
-By contrast, the `PUT` and `DELETE` methods are commonly used by modern RESTful applications to create and delete objects. For example, the API request below could be use to create a widget called "mywidget" with a value of 10:
+By contrast, the `PUT` and `DELETE` methods are commonly used by modern RESTful applications to create and delete objects. For example, the API request below could be used to create a widget called "mywidget" with a value of 10:
 
 ```http
 PUT /api/widgets/mywidget HTTP/1.1
@@ -112,7 +112,7 @@ Content-Length: 34
 {"value":"10"}
 ```
 
-A similar requests with the DELETE method could be used to delete an object.
+A similar request with the DELETE method could be used to delete an object.
 
 ```http
 DELETE /api/widgets/mywidget HTTP/1.1
@@ -123,11 +123,11 @@ Although it may be reported by automated scanning tools, the presence of these m
 
 ### TRACE
 
-The `TRACE` method causes the server to echo back the contents of the request. This lead to a vulnerability called Cross-Site Tracing (XST) being published in [2003](https://www.cgisecurity.com/whitehat-mirror/WH-WhitePaper_XST_ebook.pdf) (PDF), which could be used to access cookies that had the `HttpOnly` flag set. The `TRACE` method has been blocked in all browsers and plugins for many years, and as such this issue is no longer exploitable. However, it may still be flagged by automated scanning tools, and the `TRACE` method being enabled on a web server suggests that is has not been properly hardened.
+The `TRACE` method (or Microsoft's equivalent `TRACK` method) causes the server to echo back the contents of the request. This lead to a vulnerability called Cross-Site Tracing (XST) being published in [2003](https://www.cgisecurity.com/whitehat-mirror/WH-WhitePaper_XST_ebook.pdf) (PDF), which could be used to access cookies that had the `HttpOnly` flag set. The `TRACE` method has been blocked in all browsers and plugins for many years, and as such this issue is no longer exploitable. However, it may still be flagged by automated scanning tools, and the `TRACE` method being enabled on a web server suggests that is has not been properly hardened.
 
 ### CONNECT
 
-The `CONNECT` method causes the web server to open a TCP connection to another system, and then to pass traffic from the client through to that system. This could allow an attacker to proxy traffic through the server, in order to hide their source address, access internal systems or access services that are bound to localhost. An example of a CONNECT request is shown below:
+The `CONNECT` method causes the web server to open a TCP connection to another system, and then to pass traffic from the client through to that system. This could allow an attacker to proxy traffic through the server, in order to hide their source address, access internal systems or access services that are bound to localhost. An example of a `CONNECT` request is shown below:
 
 ```http
 CONNECT 192.168.0.1:443 HTTP/1.1

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -257,3 +257,4 @@ HTTP/1.1 200 OK
 - [RFC 5789 - PATCH Method for HTTP](https://datatracker.ietf.org/doc/html/rfc5789)
 - [HTACCESS: BILBAO Method Exposed](https://web.archive.org/web/20160616172703/http://www.kernelpanik.org/docs/kernelpanik/bme.eng.pdf)
 - [Fortify - Misused HTTP Method Override](https://vulncat.fortify.com/en/detail?id=desc.dynamic.xtended_preview.often_misused_http_method_override)
+- [Mozilla Developer Network - Safe HTTP Methods](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP)

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -48,7 +48,7 @@ Allow: OPTIONS, GET, HEAD, POST
 
 However, some servers may not respond to `OPTIONS` requests, or may return inaccurate information. Additionally, servers may support different methods for different paths - so just because a method is not supported for the root `/` directory, this doesn't necessarily mean that it won't be supported elsewhere.
 
-An alternative way to test for supported methods is to simply make a request with that method type, and examine the server response. If the method is not permitted, the server should return a `405 Method Not Allowed` status.
+An more reliable way to test for supported methods is to simply make a request with that method type, and examine the server response. If the method is not permitted, the server should return a `405 Method Not Allowed` status.
 
 Note that some servers treat unknown methods as equivalent to `GET`, so they may respond to arbitrary methods, such as the request shown below. This can occasionally be useful to evade a web application firewall, or any other filtering that blocks specific methods.
 
@@ -63,7 +63,7 @@ Requests with arbitrary methods can also be made using cURL with the `-X` option
 curl -X FOO https://example.org
 ```
 
-There are also a variety of automated tools that can attempt to determine supported methods, such as the [`http-methods`](https://nmap.org/nsedoc/scripts/http-methods.html) Nmap script. However, these tools may not test for dangerous methods (such as `PUT` or `DELETE`), or may unintentionally cause changes to the web server if these methods are supported. As such, they should be used with care.
+There are also a variety of automated tools that can attempt to determine supported methods, such as the [`http-methods`](https://nmap.org/nsedoc/scripts/http-methods.html) Nmap script. However, these tools may not test for dangerous methods (i.e, methods that may cause changes such as `PUT` or `DELETE`), or may unintentionally cause changes to the web server if these methods are supported. As such, they should be used with care.
 
 ### PUT and DELETE
 
@@ -96,7 +96,7 @@ DELETE /test.html HTTP/1.1
 Host: example.org
 ```
 
-Or with cURL
+Or with cURL:
 
 ```bash
 curl http://example.org/test.html -X DELETE
@@ -123,7 +123,7 @@ DELETE /api/users/foo HTTP/1.1
 Host: example.org
 ```
 
-Although it may be reported by automated scanning tools, the presence of these methods on a RESTful API **is not a security issue**. However, this functionality may have other vulnerabilities (such as weak access control), should be thoroughly tested.
+Although it may be reported by automated scanning tools, the presence of these methods on a RESTful API **is not a security issue**. However, this functionality may have other vulnerabilities (such as weak access control), and should be thoroughly tested.
 
 ### TRACE
 
@@ -171,11 +171,11 @@ Host: example.org
 }
 ```
 
-As with the `PUT` method, this functionality may have access control weaknesses or other vulnerabilities. Additionally, applications may not performed the same level of input validation when modifying an object as they do when creating one. This could potentially allow malicious values to be injected (such as in a stored cross-site scripting attack), or could allow broken or invalid objects that may result in business logic related issues.
+As with the `PUT` method, this functionality may have access control weaknesses or other vulnerabilities. Additionally, applications may not perform the same level of input validation when modifying an object as they do when creating one. This could potentially allow malicious values to be injected (such as in a stored cross-site scripting attack), or could allow broken or invalid objects that may result in business logic related issues.
 
 ### Testing for Access Control Bypass
 
-If a page on the application redirects users to a login page with a `302` code when they try and access it direct, it may be possible to bypass this by making a request with a different HTTP method, such as `HEAD`, `POST` or even a made up method such as `FOO`. If the web application responds with a `HTTP/1.1 200 OK` rather than the expected `HTTP/1.1 302 Found` then it may be possible to bypass the authentication or authorization. The example below shows how a `HEAD` request may result in a page setting administrative cookies, rather than redirecting the user to a login page:
+If a page on the application redirects users to a login page with a `302` code when they attempt and access it directly, it may be possible to bypass this by making a request with a different HTTP method, such as `HEAD`, `POST` or even a made up method such as `FOO`. If the web application responds with a `HTTP/1.1 200 OK` rather than the expected `HTTP/1.1 302 Found` then it may be possible to bypass the authentication or authorization. The example below shows how a `HEAD` request may result in a page setting administrative cookies, rather than redirecting the user to a login page:
 
 ```http
 HEAD /admin/ HTTP/1.1

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -188,7 +188,7 @@ HTTP/1.1 200 OK
 Set-Cookie: adminSessionCookie=[...];
 ```
 
-Alternatively, it may be possible make direct requests to pages that cause actions, such as:
+Alternatively, it may be possible to make direct requests to pages that cause actions, such as:
 
 ```http
 HEAD /admin/createUser.php?username=foo&password=bar&role=admin HTTP/1.1


### PR DESCRIPTION
As per discussion on #852, the HTTP methods testing could do with a few updates. I've not gone through and done a proper QA on grammar, so the main questions are:

* Is it accurate?
* Is the structure sensible?
* Is there anything that needs adding?

I'm also a bit unsure about the "Testing for Access Control Bypass" section. I've never seen this issue, and the reference for it seems to be an [Archive.org link to a paper from 2004](https://web.archive.org/web/20160616172703/http://www.kernelpanik.org/docs/kernelpanik/bme.eng.pdf).

Has anyone ever come across this, and is it relevant enough to keep in the guide? Or should it be cut out as a niche legacy issue?

Any thoughts, comments and suggestions are welcome.