### PR TITLE
Add missing article in sentences

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage.md
@@ -11,7 +11,7 @@ This section describes how to test various metadata files for information leakag
 ## Test Objectives
 
 - Identify hidden or obfuscated paths and functionality through the analysis of metadata files.
-- Extract and map other information that could lead to better understanding of the systems at hand.
+- Extract and map other information that could lead to a better understanding of the systems at hand.
 
 ## How to Test
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver.md
@@ -19,7 +19,7 @@ To address these issues, it is necessary to perform web application discovery.
 
 ## Test Objectives
 
-- Enumerate the applications within scope that exist on a web server.
+- Enumerate the applications within the scope that exist on a web server.
 
 ## How to Test
 


### PR DESCRIPTION
There were some missing articles in the document text. This has been fixed now.