### PR TITLE
Remove Broken Link From #References

### DIFF
--- a/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md
+++ b/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md
@@ -176,5 +176,5 @@ Ensure default system accounts and test accounts are deleted prior to releasing 
 
 ## References
 
-- [Marco Mella, Sun Java Access & Identity Manager Users enumeration](https://securiteam.com/exploits/5ep0f0uquo/)
+- [Marco Mella, Sun Java Access & Identity Manager Users enumeration](https://www.exploit-db.com/exploits/32762)
 - [Username Enumeration Vulnerabilities](https://www.gnucitizen.org/blog/username-enumeration-vulnerabilities/)


### PR DESCRIPTION
There is a broken link in the Reference section at **wstg/document/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md**.

This has been removed and replaced with another link to the exploit: https://www.exploit-db.com/exploits/32762.