### PR TITLE
Remove Broken Link From Whitepapers

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
@@ -66,7 +66,7 @@ One way to potentially assign data to PHP variables is via HTTP Parameter Pollut
 
 ### Whitepapers
 
-- [Bryan Sullivan from Adobe: "NoSQL, But Even Less Security"](https://blogs.adobe.com/asset/files/2011/04/NoSQL-But-Even-Less-Security.pdf)
+- [Bryan Sullivan from Adobe: "NoSQL, But Even Less Security"](https://repository.root-me.org/Exploitation%20-%20Web/EN%20-%20NoSQL%20But%20Even%20Less%20Security.pdf)
 - [Erlend from Bekk Consulting: "[Security] NOSQL-injection"](https://erlend.oftedal.no/blog/?blogid=110)
 - [Felipe Aragon from Syhunt: "NoSQL/SSJS Injection"](http://www.syhunt.com/en/?n=Articles.NoSQLInjection)
 - [MongoDB Documentation: "How does MongoDB address SQL or Query injection?"](https://docs.mongodb.org/manual/faq/developers/#how-does-mongodb-address-sql-or-query-injection)


### PR DESCRIPTION
There is a broken link in the Whitepapers section at **wstg/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md**.

This has been removed and replaced with another link to the PDF document: https://repository.root-me.org/Exploitation%20-%20Web/EN%20-%20NoSQL%20But%20Even%20Less%20Security.pdf.