### PR TITLE
Remove Broken Links From Whitepapers

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
@@ -66,10 +66,10 @@ One way to potentially assign data to PHP variables is via HTTP Parameter Pollut
 
 ### Whitepapers
 
-- [Bryan Sullivan from Adobe: "NoSQL, But Even Less Security"](https://blogs.adobe.com/asset/files/2011/04/NoSQL-But-Even-Less-Security.pdf)
+- [Bryan Sullivan from Adobe: "NoSQL, But Even Less Security"](https://repository.root-me.org/Exploitation%20-%20Web/EN%20-%20NoSQL%20But%20Even%20Less%20Security.pdf)
 - [Erlend from Bekk Consulting: "[Security] NOSQL-injection"](https://erlend.oftedal.no/blog/?blogid=110)
 - [Felipe Aragon from Syhunt: "NoSQL/SSJS Injection"](http://www.syhunt.com/en/?n=Articles.NoSQLInjection)
 - [MongoDB Documentation: "How does MongoDB address SQL or Query injection?"](https://docs.mongodb.org/manual/faq/developers/#how-does-mongodb-address-sql-or-query-injection)
-- [PHP Documentation: "MongoCollection::find"](https://www.php.net/manual/ro/mongocollection.find.php)
+- [PHP Documentation: "MongoCollection::find"](https://doc.bccnsoft.com/docs/php-docs-7-en/mongocollection.find.html)
 - [Hacking NodeJS and MongoDB](https://blog.websecurify.com/2014/08/hacking-nodejs-and-mongodb.html)
 - [Attacking NodeJS and MongoDB](https://blog.websecurify.com/2014/08/attacks-nodejs-and-mongodb-part-to.html)

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
@@ -70,6 +70,6 @@ One way to potentially assign data to PHP variables is via HTTP Parameter Pollut
 - [Erlend from Bekk Consulting: "[Security] NOSQL-injection"](https://erlend.oftedal.no/blog/?blogid=110)
 - [Felipe Aragon from Syhunt: "NoSQL/SSJS Injection"](http://www.syhunt.com/en/?n=Articles.NoSQLInjection)
 - [MongoDB Documentation: "How does MongoDB address SQL or Query injection?"](https://docs.mongodb.org/manual/faq/developers/#how-does-mongodb-address-sql-or-query-injection)
-- [PHP Documentation: "MongoCollection::find"](https://doc.bccnsoft.com/docs/php-docs-7-en/mongocollection.find.html)
+- [PHP Documentation: "MongoDB Driver Classes"](https://www.php.net/manual/en/book.mongodb.php)
 - [Hacking NodeJS and MongoDB](https://blog.websecurify.com/2014/08/hacking-nodejs-and-mongodb.html)
 - [Attacking NodeJS and MongoDB](https://blog.websecurify.com/2014/08/attacks-nodejs-and-mongodb-part-to.html)


### PR DESCRIPTION
There are broken links in the Whitepapers section at **wstg/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md**.

These have been removed and replaced with alternate links for the respective documents.