### PR TITLE
chore: Missed Textlint fixes

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -57,7 +57,7 @@ FOO / HTTP/1.1
 Host: example.org
 ```
 
-Requests with arbitrary methods can also be made using cURL with the `-X` option:
+Requests with arbitrary methods can also be made using curl with the `-X` option:
 
 ```bash
 curl -X FOO https://example.org

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses.md
@@ -177,7 +177,7 @@ After stepping through the OAuth flow and using the application, a few requests 
 
 ## Remediation
 
-- When implementing OAuth, always consider the technology used and whether the application is a server-side application that can avoid revealing secrets, or a client side application that cannot.
+- When implementing OAuth, always consider the technology used and whether the application is a server-side application that can avoid revealing secrets, or a client-side application that cannot.
 - In almost any case, use the Authorization Code flow with PKCE. One exception may be machine-to-machine flows.
 - Use POST parameters or header values to transport secrets.
 - When no other possibilities exists (for example, in legacy applications that can not be migrated), implement additional security headers such as a `Referrer-Policy`.


### PR DESCRIPTION
I ran textlint with our rules locally. Amazingly these are the only mistakes it found for the 6mo+ that the textling workflow has been broken.

```bash
cd document
touch log.txt
or FILE in `find . -name '*.md'`; do echo $FILE && textlint --config .github/configs/.textlintrc --fix --rule terminology $FILE | tee -a log.txt; done
```

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>