### PR TITLE
Update make-json.sh use latest not stable

### DIFF
--- a/.github/scripts/make-json.sh
+++ b/.github/scripts/make-json.sh
@@ -67,7 +67,7 @@ for d in */ ; do
                         # Add test ID, test name and reference link from the file
                         echo "                \"name\":\"${tname}\","  >> checklist.json
                         echo "                \"id\":\"${tid}\","  >> checklist.json
-                        echo "                \"reference\":\"https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/$tref\","  >> checklist.json
+                        echo "                \"reference\":\"https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/$tref\","  >> checklist.json
                         echo "                \"objectives\":["  >> checklist.json
                         # Add objective array
                         objcount=0


### PR DESCRIPTION
Since this runs on every PR merge it doesn't make sense to generate the links based on `/stable/` use `/latest/` instead.
