### PR TITLE
Add Reference Links Specific To Apache And Nginx

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.md
@@ -45,3 +45,5 @@ Strict-Transport-Security: max-age=31536000
 - [OWASP HTTP Strict Transport Security](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html)
 - [OWASP Appsec Tutorial Series - Episode 4: Strict Transport Security](https://www.youtube.com/watch?v=zEV3HOuM_Vw)
 - [HSTS Specification](https://tools.ietf.org/html/rfc6797)
+- [Enable HTTP Strict Transport Security Via HTACCESS In Apache](https://www.jinsonvarghese.com/whats-on-my-htaccess/)
+- [Enable HTTP Strict Transport Security In Nginx](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/)

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.md
@@ -45,5 +45,5 @@ Strict-Transport-Security: max-age=31536000
 - [OWASP HTTP Strict Transport Security](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html)
 - [OWASP Appsec Tutorial Series - Episode 4: Strict Transport Security](https://www.youtube.com/watch?v=zEV3HOuM_Vw)
 - [HSTS Specification](https://tools.ietf.org/html/rfc6797)
-- [Enable HTTP Strict Transport Security Via HTACCESS In Apache](https://www.jinsonvarghese.com/whats-on-my-htaccess/)
+- [Enable HTTP Strict Transport Security In Apache](https://https.cio.gov/hsts/)
 - [Enable HTTP Strict Transport Security In Nginx](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/)


### PR DESCRIPTION
Present links do not have information specific to enabling HSTS in the two most popular web servers, Apache and Nginx.

I have now added a link each for Apache (couldn't find an official Apache article; please suggest if any alternate link need to be used) and Nginx (used an official Nginx article). 