### PR TITLE
Fix "effeciently" Typo

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection.md
@@ -12,7 +12,7 @@ ORM layers can be prone to vulnerabilities, as they extend the surface of attack
 
 ### Identify the ORM Layer
 
-To effeciently test and understand what's happening between your requests and the backend queries, and as with everything related to conducting proper testing, it is essential to identify the technology being used. By following the [information gathering](../01-Information_Gathering/README.md) chapter, you should be aware of the technology being used by the application at hand. Check this [list mapping languages to their respective ORMs](https://en.wikipedia.org/wiki/List_of_object-relational_mapping_software).
+To efficiently test and understand what's happening between your requests and the backend queries, and as with everything related to conducting proper testing, it is essential to identify the technology being used. By following the [information gathering](../01-Information_Gathering/README.md) chapter, you should be aware of the technology being used by the application at hand. Check this [list mapping languages to their respective ORMs](https://en.wikipedia.org/wiki/List_of_object-relational_mapping_software).
 
 ### Abusing the ORM Layer
 


### PR DESCRIPTION
Spelling error has been fixed in the **05.7-Testing_for_ORM_Injection.md** document.