### PR TITLE
Fix "revelant" Typo

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
@@ -69,7 +69,7 @@ The following examples can be used.
 
 `http://<webmail>/src/read_body.php?mailbox=INBOX PARAMETER2&passed_id=46106&startMessage=1`
 
-- Add non standard special characters (i.e.: `\`, `'`, `"`, `@`, `#`, `!`, `|`):
+- Add non-standard special characters (i.e.: `\`, `'`, `"`, `@`, `#`, `!`, `|`):
 
 `http://<webmail>/src/read_body.php?mailbox=INBOX"&passed_id=46106&startMessage=1`
 
@@ -104,7 +104,7 @@ Server responded: Unexpected extra arguments to Select
 
 The situation S2 is harder to test successfully. The tester needs to use blind command injection in order to determine if the server is vulnerable.
 
-On the other hand, the last situation (S3) is not revelant in this paragraph.
+On the other hand, the last situation (S3) is not relevant in this paragraph.
 
 > List of vulnerable parameters
 >


### PR DESCRIPTION
Fixed the typo in the **10-Testing_for_IMAP_SMTP_Injection.md** document.