### PR TITLE
Fix "Comand" Typo

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.md
@@ -104,7 +104,7 @@ If the application doesn't validate the request, we can obtain the following res
 
 In this case, we have successfully performed an OS injection attack.
 
-## Special Characters for Comand Injection
+## Special Characters for Command Injection
 
 The following special character can be used for command injection such as `|` `;` `&` `$` `>` `<` `'` `!`
 


### PR DESCRIPTION
Fixed a spelling error in the **12-Testing_for_Command_Injection.md** document.