### PR TITLE
Fix "approprate" Typo

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection.md
@@ -113,7 +113,7 @@ To send the fuzzing input file to the web application under test, use the follow
 
 `wfuzz -c -z file,fuzz.txt,urlencode https://vulnerable_host/userinfo?username=FUZZ`
 
-In the above call, the `urlencode` argument enables the approprate escaping for the strings and `FUZZ` (with the capital letters) tells the tool where to introduce the inputs.
+In the above call, the `urlencode` argument enables the appropriate escaping for the strings and `FUZZ` (with the capital letters) tells the tool where to introduce the inputs.
 
 An example output is as follows
 


### PR DESCRIPTION
Fixed the typo in the **13-Testing_for_Format_String_Injection.md** document