### PR TITLE
Fix "Wikepedia" Typo

### DIFF
--- a/.github/configs/.textlintrc
+++ b/.github/configs/.textlintrc
@@ -47,6 +47,7 @@
 				"Wasm",
 				"WebAssembly",
 				"WebStorm",
+				"Wikipedia",
 				"WordPress",
 				"YouTube",
 				[

--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle.md
@@ -81,5 +81,5 @@ Verify that all places where encrypted data from the client, that should only be
 
 ## References
 
-- [Wikepedia - Padding Oracle Attack](https://en.wikipedia.org/wiki/Padding_oracle_attack)
+- [Wikipedia - Padding Oracle Attack](https://en.wikipedia.org/wiki/Padding_oracle_attack)
 - [Juliano Rizzo, Thai Duong, "Practical Padding Oracle Attacks"](https://www.usenix.org/event/woot10/tech/full_papers/Rizzo.pdf)


### PR DESCRIPTION
Fixed the spelling error in the **02-Testing_for_Padding_Oracle.md** document.