### PR TITLE
Fix "encyrption" Typo; Add Missing Apostrophe

### DIFF
--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md
@@ -28,7 +28,7 @@ Examples for Personal Identifying Information (PII) are:
 - Medical insurance information
 - Student information
 - Credit and debit card numbers
-- Drivers license and State ID information
+- Driver's license and State ID information
 
 ## Test Objectives
 
@@ -118,7 +118,7 @@ If the web application has features that allow a user to change an account or ca
 
 Use one of the following techniques to search for sensitive information.
 
-Checking if password or encyrption key is hardcoded in the source code or configuration files.
+Checking if password or encryption key is hardcoded in the source code or configuration files.
 
 `grep -r –E "Pass | password | pwd |user | guest| admin | encry | key | decrypt | sharekey " ./PathToSearch/`
 


### PR DESCRIPTION
Fixed these issues in the **03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels.md** document.