### PR TITLE
Fix "occurence" Spelling Error In Multiple Places

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
@@ -54,7 +54,7 @@ Given the URL and querystring: `http://example.com/?color=red&color=blue`
   | JSP, Servlet / Jetty  | First occurrence only | color=red |
   | IBM Lotus Domino | Last occurrence only | color=blue |
   | IBM HTTP Server | First occurrence only | color=red |
-  | node.js / express | First occurence only | color=red |
+  | node.js / express | First occurrence only | color=red |
   | mod_perl, libapreq2 / Apache | First occurrence only | color=red |
   | Perl CGI / Apache | First occurrence only | color=red |
   | mod_wsgi (Python) / Apache | First occurrence only | color=red |

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/20-Testing_for_Mass_Assignment.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/20-Testing_for_Mass_Assignment.md
@@ -135,7 +135,7 @@ Access to the DB schema or to the source code allows also to easily identify sen
 
 #### Java
 
-Spring MVC allows to automatically bind user input into object. Identify the controllers that handle state-changing requests (e.g. find the occurences of `@RequestMapping`) then verify if controls are in place (both on the controller or on the involved models). Limitations on the exploitation of the mass assignment can be, for example, in the form of:
+Spring MVC allows to automatically bind user input into object. Identify the controllers that handle state-changing requests (e.g. find the occurrences of `@RequestMapping`) then verify if controls are in place (both on the controller or on the involved models). Limitations on the exploitation of the mass assignment can be, for example, in the form of:
 
 - list of bindlable fields via `setAllowedFields` method of the `DataBinder` class (e.g. `binder.setAllowedFields(["username","password","email"])`)
 - list of non-bindlable fields via `setDisallowedFields` method of the `DataBinder` class (e.g. `binder.setDisallowedFields(["isAdmin"])`)


### PR DESCRIPTION
This issue has been fixed in the **04-Testing_for_HTTP_Parameter_Pollution.md** and the **20-Testing_for_Mass_Assignment.md** documents.