### PR TITLE
chore: Update Testing Tools Resource (Appendix A)

### DIFF
--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -61,12 +61,14 @@ The list contains only tools that are freely available to download and use (alth
 
 ##### Remote Brute Force
 
+- [OWASP ZAP](https://www.zaproxy.org)
 - [Patator](https://github.com/lanjelot/patator)
 - [THC Hydra](https://github.com/vanhauser-thc/thc-hydra)
 - [Burp Suite Community Edition (Intruder)](https://portswigger.net/burp/communitydownload)
 
 #### Fuzzers
 
+- [Ffuf](https://github.com/ffuf/ffuf)
 - [Wfuzz](https://github.com/xmendez/wfuzz)
 - [Jdam](https://gitlab.com/michenriksen/jdam)
 
@@ -95,9 +97,9 @@ The list contains only tools that are freely available to download and use (alth
 
 ## Vulnerability Scanners
 
-- [w3af](https://w3af.org)
 - [OWASP ZAP](https://www.zaproxy.org)
 - [Nikto](https://cirt.net/Nikto2)
+- [Nuclei](https://nuclei.projectdiscovery.io/)
 
 ## Exploitation Frameworks
 


### PR DESCRIPTION
This PR is a follow-up to OWASP/wstg#901.

- Drop w3af which seems to no longer be maintained.
- Add Ffuf.
- Add Nuclei.
- Add ZAP to "Remote Brute Force"

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>