### PR TITLE
Fix two typos in cookie attribute guide

### DIFF
--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
@@ -101,7 +101,7 @@ The [`__Host-`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Cookie
   1. The cookie must be set with the [`Secure` attribute](#secure-attribute).
   2. The cookie must be set from a URI considered secure by the user agent.
   3. Sent only to the host who set the cookie and MUST NOT include any [`Domain` attribute](#domain-attribute).
-  4. The cookie must be set with the [`Path` attribute](#path-attribute) with a value of `/` so it would be sent to every request to the host.
+  4. The cookie must be set with the [`Path` attribute](#path-attribute) with a value of `/` so it would be sent with every request to the host.
 
 For this reason, the cookie `Set-Cookie: __Host-SID=12345; Secure; Path=/` would be accepted while any of the following ones would always be rejected:
 `Set-Cookie: __Host-SID=12345`

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
@@ -88,7 +88,7 @@ The `Lax` value is less restrictive than `Strict`. The cookie will be sent if th
 
 ##### None Value
 
-The `None` value specifies that the browser will send the cookie on cross-site requests (the normal behavior before the implementation of `SamseSite`) only if the `Secure` attribute is also used, _e.g._ `SameSite=None; Secure`. It is a recommended value, instead of not specifying any `SameSite` value, as it forces the use of the [`secure` attribute](#secure-attribute).
+The `None` value specifies that the browser will send the cookie on cross-site requests (the normal behavior before the implementation of `SameSite`) only if the `Secure` attribute is also used, _e.g._ `SameSite=None; Secure`. It is a recommended value, instead of not specifying any `SameSite` value, as it forces the use of the [`secure` attribute](#secure-attribute).
 
 ### Cookie Prefixes
 
@@ -101,7 +101,7 @@ The [`__Host-`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Cookie
   1. The cookie must be set with the [`Secure` attribute](#secure-attribute).
   2. The cookie must be set from a URI considered secure by the user agent.
   3. Sent only to the host who set the cookie and MUST NOT include any [`Domain` attribute](#domain-attribute).
-  4. The cookie must be set with the [`Path`attribute](#path-attribute) with a value of `/` so it would be sent to every request to the host.
+  4. The cookie must be set with the [`Path` attribute](#path-attribute) with a value of `/` so it would be sent to every request to the host.
 
 For this reason, the cookie `Set-Cookie: __Host-SID=12345; Secure; Path=/` would be accepted while any of the following ones would always be rejected:
 `Set-Cookie: __Host-SID=12345`


### PR DESCRIPTION
This PR fixes two typos in the cookie attributes chapter. As the changes are trivial, I did not create an issue for it first - hope this is okay.