### PR TITLE
Fix Typo

### DIFF
--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -119,7 +119,7 @@ Some implementations try and avoid this by explicitly blocking the use of the `n
 
 #### ECDSA "Psychic Signatures"
 
-A vulnerability was identified in Java version 15 to 18 where they did not correctly validate ECDSA signatures in some circumstances ([CVE-2022-21449](https://neilmadden.blog/2022/04/19/psychic-signatures-in-java/), known as "psychic signatures"). If one of these vulnerable version is used to parse a JWT using the `ES256` algorithm, this can be used to completely bypass the signature verification by tampering the body and then replacing the signature with the following value:
+A vulnerability was identified in Java version 15 to 18 where they did not correctly validate ECDSA signatures in some circumstances ([CVE-2022-21449](https://neilmadden.blog/2022/04/19/psychic-signatures-in-java/), known as "psychic signatures"). If one of these vulnerable versions is used to parse a JWT using the `ES256` algorithm, this can be used to completely bypass the signature verification by tampering the body and then replacing the signature with the following value:
 
 ```txt
 MAYCAQACAQA


### PR DESCRIPTION
As used in https://www.ibm.com/docs/en/asdc/4.0?topic=upgrades-before-upgrading-downgrading#:~:text=one%20of%20these%20versions and other official documents.

This is fixed.