### PR TITLE
WSTG-CONF-12 cover unsafe-hashes directive

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy.md
@@ -20,7 +20,7 @@ To test for misconfigurations in CSPs, look for insecure configurations by exami
 
 - `unsafe-inline` directive enables inline scripts or styles making the applications susceptible to XSS attacks.
 - `unsafe-eval` directive allows `eval()` to be used in the application.
-- `unsafe-hashes` directive allows us to provide inline code, by computing a SHA-256 hash of our code.
+- `unsafe-hashes` directive allows use of inline scripts/styles, assuming they match the specified hashes.
 - Resources such as scripts can be allowed to be loaded from any origin by the use wildcard (`*`) source.
     - Also consider wildcards based on partial matches, such as: `https://*` or `*.cdn.com`.
     - Consider whether allow listed sources provide JSONP endpoints which might be used to bypass CSP or same-origin-policy.

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy.md
@@ -66,3 +66,4 @@ object-src 'none'; base-uri 'none';
 - [Content-Security-Policy](https://content-security-policy.com/)
 - [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 - [CSP A Successful Mess Between Hardening And Mitigation](https://speakerdeck.com/lweichselbaum/csp-a-successful-mess-between-hardening-and-mitigation)
+- [The unsafe-hashes Source List Keyword](https://content-security-policy.com/unsafe-hashes/)

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy.md
@@ -20,6 +20,7 @@ To test for misconfigurations in CSPs, look for insecure configurations by exami
 
 - `unsafe-inline` directive enables inline scripts or styles making the applications susceptible to XSS attacks.
 - `unsafe-eval` directive allows `eval()` to be used in the application.
+- `unsafe-hashes` directive allows us to provide inline code, by computing a SHA-256 hash of our code.
 - Resources such as scripts can be allowed to be loaded from any origin by the use wildcard (`*`) source.
     - Also consider wildcards based on partial matches, such as: `https://*` or `*.cdn.com`.
     - Consider whether allow listed sources provide JSONP endpoints which might be used to bypass CSP or same-origin-policy.


### PR DESCRIPTION
This PR fixes #935.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Content update of WSTG-CONF-12 mentioning the unsafe-hashes CSP directive 
- #935 

Thank you for your contribution!