### PR TITLE
docs: clarify samesite attribute

### DIFF
--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
@@ -72,7 +72,15 @@ Unlike [session cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cooki
 
 #### SameSite Attribute
 
-The [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) attribute is used to assert that a cookie ought not to be sent along with cross-site requests. This feature allows the server to mitigate the risk of cross-origin information leakage. In some cases, it is used too as a risk reduction (or defense in depth mechanism) strategy to prevent [cross-site request forgery](05-Testing_for_Cross_Site_Request_Forgery.md) attacks. This attribute can be configured in three different modes:
+The
+[`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies)
+attribute can be used to assert whether a cookie should be sent along with
+cross-site requests. This feature allows the server to mitigate the risk of
+cross-origin information leakage. In some cases, it is used too as a risk
+reduction (or defense in depth mechanism) strategy to prevent [cross-site
+request forgery](05-Testing_for_Cross_Site_Request_Forgery.md) attacks.
+
+This attribute can be configured in three different modes:
 
 - `Strict`
 - `Lax`
@@ -88,7 +96,10 @@ The `Lax` value is less restrictive than `Strict`. The cookie will be sent if th
 
 ##### None Value
 
-The `None` value specifies that the browser will send the cookie on cross-site requests (the normal behavior before the implementation of `SameSite`) only if the `Secure` attribute is also used, _e.g._ `SameSite=None; Secure`. It is a recommended value, instead of not specifying any `SameSite` value, as it forces the use of the [`secure` attribute](#secure-attribute).
+The `None` value specifies that the browser will send the cookie in all
+contexts, including cross-site requests (the normal behavior before the
+implementation of `SameSite`). If `Samesite=None` is set, the `Secure` attribute
+should also be set, _e.g._ `SameSite=None; Secure`.
 
 ### Cookie Prefixes
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.md
@@ -72,15 +72,7 @@ Unlike [session cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cooki
 
 #### SameSite Attribute
 
-The
-[`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies)
-attribute can be used to assert whether a cookie should be sent along with
-cross-site requests. This feature allows the server to mitigate the risk of
-cross-origin information leakage. In some cases, it is used too as a risk
-reduction (or defense in depth mechanism) strategy to prevent [cross-site
-request forgery](05-Testing_for_Cross_Site_Request_Forgery.md) attacks.
-
-This attribute can be configured in three different modes:
+The [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) attribute can be used to assert whether a cookie should be sent along with cross-site requests. This feature allows the server to mitigate the risk of cross-origin information leakage. In some cases, it is used too as a risk reduction (or defense in depth mechanism) strategy to prevent [cross-site request forgery](05-Testing_for_Cross_Site_Request_Forgery.md) attacks. This attribute can be configured in three different modes:
 
 - `Strict`
 - `Lax`
@@ -96,10 +88,7 @@ The `Lax` value is less restrictive than `Strict`. The cookie will be sent if th
 
 ##### None Value
 
-The `None` value specifies that the browser will send the cookie in all
-contexts, including cross-site requests (the normal behavior before the
-implementation of `SameSite`). If `Samesite=None` is set, the `Secure` attribute
-should also be set, _e.g._ `SameSite=None; Secure`.
+The `None` value specifies that the browser will send the cookie in all contexts, including cross-site requests (the normal behavior before the implementation of `SameSite`). If `Samesite=None` is set, the `Secure` attribute should also be set, _e.g._ `SameSite=None; Secure`.
 
 ### Cookie Prefixes
 


### PR DESCRIPTION
Ensure that it doesn't read as if SameSite=None is the recommended value.

Note that this commit also ensures that the modified lines are wrapped at 80 characters, as mentioned in the style_guide.md (markdownlint).