### PR TITLE
fix: Link Check Workflow

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         node-version: '16'
     - name: Install dependencies
-      run: npm install -g markdown-link-check
+      run: npm install -g markdown-link-check@3.11.0
     - name: Changed Files Exporter
       if: github.event_name == 'pull_request_target'
       id: files
@@ -56,7 +56,7 @@ jobs:
     - name: Show broken links
       if: failure()
       run: |
-        cat log | awk -v RS="FILE:" 'match($0, /(\S*\.md).*\[✖\].*(\d*\slinks\schecked\.)(.*)/, arr ) { print "FILE:"arr[1] arr[3] > "brokenlinks.txt"}'
+        cat log | awk -v RS="FILE:" 'match($0, /(\S*\.md).*\[✖\].*([0-9]*\slinks\schecked\.)(.*)/, arr ) { print "FILE:"arr[1] arr[3] > "brokenlinks.txt"}'
         cat brokenlinks.txt
         rm -f err log
     - name: Upload list of broken links


### PR DESCRIPTION
- Pin markdown-link-check at 3.11.0 so ensure output consistency.
- Use digit character class for awk instead of \d.