### PR TITLE
Section 2.5 Threat Modeling: add links to pytm and Threat Dragon

### DIFF
--- a/document/2-Introduction/README.md
+++ b/document/2-Introduction/README.md
@@ -205,7 +205,16 @@ To develop a threat model, we recommend taking a simple approach that follows th
 - Exploring potential threats – develop a realistic view of potential attack vectors from an attacker’s perspective by using threat scenarios or attack trees.
 - Creating mitigation strategies – develop mitigating controls for each of the threats deemed to be realistic.
 
-The output from a threat model itself can vary but is typically a collection of lists and diagrams. Various Open Source projects and commercial products support application threat modeling methodologies that can be used as a reference for testing applications for potential security flaws in the design of the application. There is no right or wrong way to develop threat models and perform information risk assessments on applications.
+The output from a threat model itself can vary but is typically a collection of lists and diagrams.
+Various Open Source projects and commercial products support application threat modeling methodologies
+that can be used as a reference for testing applications for potential security flaws in the design of the application.
+It may be worth considering the OWASP threat modeling tool projects,
+Pythonic Threat Modeling ([pytm](https://owasp.org/www-project-pytm/))
+and [Threat Dragon](https://owasp.org/www-project-threat-dragon/),
+which provide complementary ways of creating threat models.
+
+There is no right or wrong way to develop threat models and perform information risk assessments on applications,
+so choose the tools and processes that fit with how your organisation and development teams work.
 
 ### Advantages
 

--- a/document/2-Introduction/README.md
+++ b/document/2-Introduction/README.md
@@ -208,13 +208,13 @@ To develop a threat model, we recommend taking a simple approach that follows th
 The output from a threat model itself can vary but is typically a collection of lists and diagrams.
 Various Open Source projects and commercial products support application threat modeling methodologies
 that can be used as a reference for testing applications for potential security flaws in the design of the application.
-It may be worth considering the OWASP threat modeling tool projects,
+It may be worth considering using one of the OWASP threat modeling tool projects,
 Pythonic Threat Modeling ([pytm](https://owasp.org/www-project-pytm/))
 and [Threat Dragon](https://owasp.org/www-project-threat-dragon/),
-which provide complementary ways of creating threat models.
+which provide differing but equally valid ways of creating threat models.
 
-There is no right or wrong way to develop threat models and perform information risk assessments on applications,
-so choose the tools and processes that fit with how your organisation and development teams work.
+There is no right or wrong way to develop threat models and perform information risk assessments on applications;
+be flexible and select the tools and processes that will fit with how a particular organisation or development team works.
 
 ### Advantages
 

--- a/document/2-Introduction/README.md
+++ b/document/2-Introduction/README.md
@@ -214,7 +214,7 @@ and [Threat Dragon](https://owasp.org/www-project-threat-dragon/),
 which provide differing but equally valid ways of creating threat models.
 
 There is no right or wrong way to develop threat models and perform information risk assessments on applications;
-be flexible and select the tools and processes that will fit with how a particular organisation or development team works.
+be flexible and select the tools and processes that will fit with how a particular organization or development team works.
 
 ### Advantages
 


### PR DESCRIPTION
This PR covers issue #1059 .

- [X] This PR handles the issue and requires no additional PRs.
- [X] You have validated the need for this change.

**What did this PR accomplish?**
This pull request provides links to the two OWASP threat modeling tool projects  [Pythonic Threat Modeling ](https://owasp.org/www-project-pytm/) and [Threat Dragon](https://owasp.org/www-project-threat-dragon/)
and closes #1059 