### PR TITLE
chore: Fix a typo (period at a wrong place)

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -698,7 +698,7 @@ Adding SQL inline comments can also help the SQL statement to be valid and bypas
 
 `' UNION SELECT password FROM Users WHERE name='admin'--`
 
-Adding SQL inline comments will be.
+Adding SQL inline comments will be
 
 `'/**/UNION/**/SELECT/**/password/**/FROM/**/Users/**/WHERE/**/name/**/LIKE/**/'admin'--`
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -698,7 +698,7 @@ Adding SQL inline comments can also help the SQL statement to be valid and bypas
 
 `' UNION SELECT password FROM Users WHERE name='admin'--`
 
-Adding SQL inline comments will be
+Adding SQL inline comments will be:
 
 `'/**/UNION/**/SELECT/**/password/**/FROM/**/Users/**/WHERE/**/name/**/LIKE/**/'admin'--`
 


### PR DESCRIPTION
```
Adding SQL inline comments will be.

'/**/UNION/**/SELECT/**/password/**/FROM/**/Users/**/WHERE/**/name/**/LIKE/**/'admin'--
```

--- The sentence ends with a period, (.) even though there's an example query right after it. This commit removes the period.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.