### PR TITLE
fix-1114: Broken anchor link

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md
@@ -80,7 +80,7 @@ Consider the following HTTP request:
 ![Cakephp HTTP Request](images/Cakephp_cookie.png)\
 *Figure 4.1.8-7: Cakephp HTTP Request*
 
-The cookie `CAKEPHP` has automatically been set, which gives information about the framework being used. A list of common cookie names is presented in [Cookies](#cookies) section. Limitations still exist in relying on this identification mechanism - it is possible to change the name of cookies. For example, for the selected `CakePHP` framework this could be done via the following configuration (excerpt from `core.php`):
+The cookie `CAKEPHP` has automatically been set, which gives information about the framework being used. A list of common cookie names is presented in [Cookies](#cookies-1) section. Limitations still exist in relying on this identification mechanism - it is possible to change the name of cookies. For example, for the selected `CakePHP` framework this could be done via the following configuration (excerpt from `core.php`):
 
 ```php
 /**


### PR DESCRIPTION
This PR fixes #1114.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- fixed Cookies-Link to point to "Common Identifiers"."Cookies" (same header name) by adding a "-1" to the href