### PR TITLE
Update 05-Testing_for_SQL_Injection.md

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods.md
@@ -18,7 +18,7 @@ HTTP offers a number of methods (or verbs) that can be used to perform actions o
 | [`PUT`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4) | Upload a file. | Create an object. |
 | [`DELETE`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.5) | Delete a file | Delete an object. |
 | [`CONNECT`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6) | Establish a connection to another system. | |
-| [`OPTIONS`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7) | List supported HTTP methods. | Perform a [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) request.
+| [`OPTIONS`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7) | List supported HTTP methods. | Perform a [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) request. |
 | [`TRACE`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.8) | Echo the HTTP request for debug purposes. | |
 | [`PATCH`](https://datatracker.ietf.org/doc/html/rfc5789#section-2) |  | Modify an object. |
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
@@ -175,8 +175,8 @@ The following table summarizes some special variables and functions to look at w
 |----------------|-------------------|------------------|
 | `$_GET` - HTTP GET variables  | `Request.QueryString` - HTTP GET | `doGet`, `doPost` servlets - HTTP GET and POST |
 | `$_POST` - HTTP POST variables| `Request.Form` - HTTP POST | `request.getParameter` - HTTP GET/POST variables |
-| `$_REQUEST` – HTTP POST, GET and COOKIE variables | `Server.CreateObject` - used to upload files |
-| `$_FILES` - HTTP File Upload variables |
+| `$_REQUEST` – HTTP POST, GET and COOKIE variables | `Server.CreateObject` - used to upload files | |
+| `$_FILES` - HTTP File Upload variables | | |
 
 **Note**: The table above is only a summary of the most important parameters but, all user input parameters should be investigated.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -794,7 +794,6 @@ For generic input validation security, refer to the [Input Validation CheatSheet
 ## Tools
 
 - [SQL Injection Fuzz Strings (from wfuzz tool) - Fuzzdb](https://github.com/fuzzdb-project/fuzzdb/tree/master/attack/sql-injection)
-- [sqlbftools](http://packetstormsecurity.org/files/43795/sqlbftools-1.2.tar.gz.html)
 - [Bernardo Damele A. G.: sqlmap, automatic SQL injection tool](http://sqlmap.org/)
 - [Muhaimin Dzulfakar: MySqloit, MySql Injection takeover tool](https://github.com/dtrip/mysqloit)
 - [SQL Injection - PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/SQL%20Injection)

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -509,11 +509,11 @@ Which is exploitable through the methods seen previously. What we want to obtain
 
 Through such functions, we will execute our tests on the first character and, when we have discovered the value, we will pass it to the second and so on, until we will have discovered the entire value. The tests will take advantage of the function SUBSTRING, to select only one character at a time (selecting a single character means imposing the length parameter to 1), and the function ASCII, to obtain the ASCII value, so that we can do numerical comparison. The results of the comparison will be done with all the values of the ASCII table until the right value is found. As an example, we will use the following value for `Id`:
 
-`$Id=1' AND ASCII(SUBSTRING(username,1,1))=97 AND '1'='1`
+`$Id=1' OR ASCII(SUBSTRING(username,1,1))=97 AND '1'='1`
 
 That creates the following query (from now on, we will call it "inferential query"):
 
-`SELECT field1, field2, field3 FROM Users WHERE Id='1' AND ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`
+`SELECT field1, field2, field3 FROM Users WHERE Id='1' OR ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`
 
 The previous example returns a result if and only if the first character of the field username is equal to the ASCII value 97. If we get a false value, then we increase the index of the ASCII table from 97 to 98 and we repeat the request. If instead we obtain a true value, we set the index of the ASCII table to zero and we analyze the next character, modifying the parameters of the SUBSTRING function. The problem is to understand in which way we can distinguish tests returning a true value from those that return false. To do this, we create a query that always returns false. This is possible by using the following value for `Id`:
 
@@ -529,11 +529,11 @@ In the previous discussion, we haven't dealt with the problem of determining the
 
 We will insert the following value for the field `Id`:
 
-`$Id=1' AND LENGTH(username)=N AND '1' = '1`
+`$Id=1' OR LENGTH(username)=N AND '1' = '1`
 
 Where N is the number of characters that we have analyzed up to now (not counting the null value). The query will be:
 
-`SELECT field1, field2, field3 FROM Users WHERE Id='1' AND LENGTH(username)=N AND '1' = '1'`
+`SELECT field1, field2, field3 FROM Users WHERE Id='1' OR LENGTH(username)=N AND '1' = '1'`
 
 The query returns either true or false. If we obtain true, then we have completed the inference and, therefore, we know the value of the parameter. If we obtain false, this means that the null character is present in the value of the parameter, and we must continue to analyze the next parameter until we find another null value.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL.md
@@ -60,7 +60,7 @@ For example the following injection will result in an error:
 
 #### Fingerprinting MySQL
 
-Of course, the first thing to know is if there's MySQL DBMS as a back end database. MySQL server has a feature that is used to let other DBMS ignore a clause in MySQL dialect. When a comment block `'/**/'` contains an exclamation mark `'/*! sql here*/'` it is interpreted by MySQL, and is considered as a normal comment block by other DBMS as explained in [MySQL manual](https://dev.mysql.com/doc/refman/8.0/en/comments.html).
+Of course, the first thing to know is if there's MySQL DBMS as a backend database. MySQL server has a feature that is used to let other DBMS ignore a clause in MySQL dialect. When a comment block `'/**/'` contains an exclamation mark `'/*! sql here*/'` it is interpreted by MySQL, and is considered as a normal comment block by other DBMS as explained in [MySQL manual](https://dev.mysql.com/doc/refman/8.0/en/comments.html).
 
 Example:
 
@@ -212,7 +212,6 @@ For a complete list, refer to the [MySQL manual](https://dev.mysql.com/doc/refma
 ## Tools
 
 - [Francois Larouche: Multiple DBMS SQL Injection tool](http://www.sqlpowerinjector.com/index.htm)
-- [Reversing.org - sqlbftools](https://packetstormsecurity.com/files/43795/sqlbftools-1.2.tar.gz.html)
 - [Bernardo Damele A. G.: sqlmap, automatic SQL injection tool](https://sqlmap.org/)
 - [Muhaimin Dzulfakar: MySqloit, MySql Injection takeover tool](https://code.google.com/archive/p/mysqloit/)
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection.md
@@ -45,7 +45,7 @@ Based on their [blog article](https://blog.ripstech.com/2020/exploiting-hibernat
 | DBMS       | SQL Injection                                                         |
 |------------|-----------------------------------------------------------------------|
 | MySQL      | `abc\' INTO OUTFILE --`                                               |
-| PostgreSQL | `$$='$$=chr(61)||chr(0x27) and 1=pg_sleep(2)||version()'`             |
+| PostgreSQL | `$$='$$=chr(61)|| chr(0x27) and 1=pg_sleep(2)|| version()'`             |
 | Oracle     | `NVL(TO_CHAR(DBMS_XMLGEN.getxml('select 1 where 1337>1')),'1')!='1'`  |
 | MS SQL     | `1<LEN(%C2%A0(select%C2%A0top%C2%A01%C2%A0name%C2%A0from%C2%A0users)` |
 


### PR DESCRIPTION
### Fix boolean logic error for inference methods
The current inferential query will only work in cases where the Id value actually equals 1. In blind SQL cases this value is likely not known.
`SELECT field1, field2, field3 FROM Users WHERE Id='1' AND I(SUBSTRING(username,1,1))=97 AND '1'='1'`

Changing the first AND to an OR will ensure the inferential query executes regardless of the Id value.
`SELECT field1, field2, field3 FROM Users WHERE Id='1' OR ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`