### PR TITLE
Introduction - Add "Disable Compensating Controls For Testers"

### DIFF
--- a/document/2-Introduction/README.md
+++ b/document/2-Introduction/README.md
@@ -138,6 +138,10 @@ It is critical not to perform a superficial security review of an application an
 
 While black-box penetration test results can be impressive and useful to demonstrate how vulnerabilities are exposed in a production environment, they are not the most effective or efficient way to secure an application. It is difficult for dynamic testing to test the entire codebase, particularly if many nested conditional statements exist. If the source code for the application is available, it should be given to the security staff to assist them while performing their review. It is possible to discover vulnerabilities within the application source that would be missed during a black-box engagement.
 
+### Disable Compensating Controls For Testers
+
+Testing traffic should be allowed through compensating controls such as a Web Application Firewall (WAF). While a WAF can block many attacks on an application, a sophisticated attacker can bypass the control and exploit the vulnerable underlying application with enough time and dedication. Like providing source code access, turning off the compensating control enables the security staff to dedicate all their focus to the application logic. A white-box penetration test aims to find security vulnerabilities in the product itself, not the systems that proxy traffic to the production environment.
+
 ### Develop Metrics
 
 An important part of a good security program is the ability to determine if things are getting better. It is important to track the results of testing engagements, and develop metrics that will reveal the application security trends within the organization.

--- a/document/2-Introduction/README.md
+++ b/document/2-Introduction/README.md
@@ -138,7 +138,7 @@ It is critical not to perform a superficial security review of an application an
 
 While black-box penetration test results can be impressive and useful to demonstrate how vulnerabilities are exposed in a production environment, they are not the most effective or efficient way to secure an application. It is difficult for dynamic testing to test the entire codebase, particularly if many nested conditional statements exist. If the source code for the application is available, it should be given to the security staff to assist them while performing their review. It is possible to discover vulnerabilities within the application source that would be missed during a black-box engagement.
 
-### Disable Compensating Controls For Testers
+### Disable Compensating Controls for Testers
 
 Testing traffic should be allowed through compensating controls such as a Web Application Firewall (WAF). While a WAF can block many attacks on an application, a sophisticated attacker can bypass the control and exploit the vulnerable underlying application with enough time and dedication. Like providing source code access, turning off the compensating control enables the security staff to dedicate all their focus to the application logic. A white-box penetration test aims to find security vulnerabilities in the product itself, not the systems that proxy traffic to the production environment.
 


### PR DESCRIPTION
Add a header to the introduction page recommending disabling compensating controls such as a WAF. Testers can use this section to provide product teams with an authoritative resource on how to set up a penetration test effectively.

There is a widespread belief that penetration tests should be conducted in a black-box setting as this is more realistic. While true, the goal of this PR is to help educate that white-box penetration tests without compensating controls are much more effective in securing an application.