### PR TITLE
Change lint workflows into dual step

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,13 @@ For building PDF and EPUB e-Books at release.
 - See: `/.github/pdf/` in the root of the repository for PDF build specific configurations.
 - See: `/.github/epub/` in the root of the repository for EPUB build specific configurations.
 
+## `comment.yml`
+
+Triggered by the completion of other workflows in order to comment lint or other results on PRs.
+The workflows which leverage it should create a `pr_number` text file and `artifact.txt` with the content to be commented, which are attached to their workflow runs as `artifact`.
+
+- Trigger: Other workflows `workflow_run`.
+
 ## `dummy.yml`
 
 Utility action so that PRs without Markdown files can pass the branch protection rules. `lint` is required per the branch protection rules. If a PR contains no Markdown files (e.g. only an image or YAML that isn't linted) the dummy runs and passes the branch protection requirement.

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,37 @@
+name: Comment
+
+on:
+  workflow_run:
+    workflows: ['Markdown Link Check', 'Markdown Lint Check', 'Markdown Terminology Lint Check']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            const issue_number = Number(fs.readFileSync('./pr_number'));
+            const artifactString = fs.readFileSync('./artifact.txt').toString().trimEnd();
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: `${artifactString}`
+            });

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,7 +1,7 @@
 name: Markdown Link Check
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
     - '**.md'
     - '!.github/**'
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   link-check:
@@ -20,6 +19,12 @@ jobs:
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
+    - name: Save PR number
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        mkdir -p ./pr
+        echo $PR_NUMBER > pr_number
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -27,13 +32,13 @@ jobs:
     - name: Install dependencies
       run: npm install -g markdown-link-check@3.11.0
     - name: Changed Files Exporter
-      if: github.event_name == 'pull_request_target'
+      if: github.event_name == 'pull_request'
       id: files
       uses: umani/changed-files@v4.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: PR link check
-      if: github.event_name == 'pull_request_target'
+      if: github.event_name == 'pull_request'
       env:
         FILES: '${{ steps.files.outputs.files_updated }} ${{ steps.files.outputs.files_created }}'
       run: |
@@ -57,25 +62,18 @@ jobs:
       run: |
         cat log | awk -v RS="FILE:" 'match($0, /(\S*\.md).*\[✖\].*([0-9]*\slinks\schecked\.)(.*)/, arr ) { print "FILE:"arr[1] arr[3] > "brokenlinks.txt"}'
         cat brokenlinks.txt
+    - name: Create artifact for comment
+      if: failure()
+      run: |
+        echo "**The following links are broken:**" > artifact.txt
+        # Copy to generic name for commenting
+        cat brokenlinks.txt | tee -a artifact.txt
         rm -f err log
     - name: Upload list of broken links
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: broken-links
-        path: brokenlinks.txt
-    - name: Comment Broken Links
-      if: ${{ failure() && github.event_name == 'pull_request_target' }}
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const fs = require("fs");
-          const brokenLinksPath = `${process.env.GITHUB_WORKSPACE}/brokenlinks.txt`;
-          const brokenLinksString = fs.readFileSync(brokenLinksPath).toString().trimEnd();
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `**The following links are broken:** \n${brokenLinksString}`
-          })
+        name: artifact
+        path: |
+          artifact.txt
+          pr_number

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -22,9 +22,7 @@ jobs:
     - name: Save PR number
       env:
         PR_NUMBER: ${{ github.event.number }}
-      run: |
-        mkdir -p ./pr
-        echo $PR_NUMBER > pr_number
+      run: echo $PR_NUMBER > pr_number
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/md-lint-check.yml
+++ b/.github/workflows/md-lint-check.yml
@@ -23,9 +23,7 @@ jobs:
     - name: Save PR number
       env:
         PR_NUMBER: ${{ github.event.number }}
-      run: |
-        mkdir -p ./pr
-        echo $PR_NUMBER > pr_number
+      run: echo $PR_NUMBER > pr_number
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/md-lint-check.yml
+++ b/.github/workflows/md-lint-check.yml
@@ -1,7 +1,7 @@
 name: Markdown Lint Check
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
     - master
     paths:
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   lint:
@@ -21,6 +20,12 @@ jobs:
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
+    - name: Save PR number
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        mkdir -p ./pr
+        echo $PR_NUMBER > pr_number
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -34,25 +39,18 @@ jobs:
       run: |
         cat lint.txt
         sed -i 's/```/triple-backtick/g' lint.txt
-    - name: Attach Linting Issues
+    - name: Create artifact for comment
       if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: Linting Issues
-        path: lint.txt
-    - name: Comment Linting Issues
+      run: |
+        echo "**The following issues were identified:**" > artifact.txt
+        # Copy to generic name for commenting
+        cat lint.txt | tee -a artifact.txt
+    - name: Upload list of issues
       if: failure()
-      uses: actions/github-script@v7
+      uses: actions/upload-artifact@v4
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const fs = require("fs");
-          const lintPath = `${process.env.GITHUB_WORKSPACE}/lint.txt`;
-          const lintString = fs.readFileSync(lintPath).toString().trimEnd();
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `**The following issues were identified:** \n${lintString}`
-          })
+        name: artifact
+        path: |
+          artifact.txt
+          pr_number
 

--- a/.github/workflows/md-textlint-check.yml
+++ b/.github/workflows/md-textlint-check.yml
@@ -30,9 +30,7 @@ jobs:
     - name: Save PR number
       env:
         PR_NUMBER: ${{ github.event.number }}
-      run: |
-        mkdir -p ./pr
-        echo $PR_NUMBER > pr_number
+      run: echo $PR_NUMBER > pr_number
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/md-textlint-check.yml
+++ b/.github/workflows/md-textlint-check.yml
@@ -1,7 +1,7 @@
 name: Markdown Terminology Lint Check
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
     - master
     paths:
@@ -27,6 +27,12 @@ jobs:
       with:
         repository: OWASP/wstg
         path: base
+    - name: Save PR number
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        mkdir -p ./pr
+        echo $PR_NUMBER > pr_number
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -55,24 +61,18 @@ jobs:
       run: |
         cat log.txt
         cat log.txt | grep -v '✔ Fixed' | tr '✔' '✖' >mistakes.txt
-    - name: Attach Mistakes
+    - name: Create artifact for comment
       if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: Terminology Mistakes
-        path: mistakes.txt
-    - name: Comment Mistakes
+      run: |
+        echo "**The following mistakes were identified:**" > artifact.txt
+        # Copy to generic name for commenting
+        cat mistakes.txt | tee -a artifact.txt
+    - name: Upload list of mistakes
       if: failure()
-      uses: actions/github-script@v7
+      uses: actions/upload-artifact@v4
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const fs = require("fs");
-          const mistakesPath = `${process.env.GITHUB_WORKSPACE}/mistakes.txt`;
-          const mistakesString = fs.readFileSync(mistakesPath).toString().trimEnd();
-          github.rest.issues.createComment({
-            issue_number: ${{ github.event.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `**The following mistakes were identified:** \n${mistakesString}`
-          })
+        name: artifact
+        path: |
+          artifact.txt
+          pr_number
+


### PR DESCRIPTION
- The current MD Link, MD Lint, and MD Text Lint workflows now trigger a generic comment workflow upon completion (workflow_run), leveraging generic artifact naming to produce PR comments.

Testing was done in: https://github.com/kingthorin/wstgtest (This link may expire at some point if/when the testing repo is deleted).