### PR TITLE
Remove redundant section in privilege escalation document

### DIFF
--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation.md
@@ -184,10 +184,6 @@ For example:
 startswith(), endswith(), contains(), indexOf()
 ```
 
-### Weak SessionID
-
-Weak Session ID has algorithm may be vulnerable to brute force attack. For example, one site is using `MD5(Password + UserID)` as sessionID. Then, testers may guess or generate the sessionID for other users.
-
 ## References
 
 ### Whitepapers


### PR DESCRIPTION
This PR fixes #1130

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**
- Removed the “Weak SessionID” section, as it is already described in great detail in [WSTG-SESS-01 - Session Analysis](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema.md#session-analysis).