### PR TITLE
Added modern reconnaissance tools (Waybackurls, GAU, Unfurl) to Content Discovery section

### DIFF
--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -109,7 +109,7 @@ gau example.com
 - [Unfurl](https://github.com/tomnomnom/unfurl)
     - Unfurl extracts subdomains, paths, and parameters from URLs for deeper analysis.
     - **Usage:**
-      
+
 ```bash
 unfurl "https://example.com/page?query=123"
 ```

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -90,6 +90,24 @@ The list contains only tools that are freely available to download and use (alth
 ### Content Discovery
 
 - [Gobuster](https://github.com/OJ/gobuster)
+- [Waybackurls](https://github.com/tomnomnom/waybackurls)
+    - Waybackurls fetches all URLs known to the Wayback Machine for a given domain, useful for reconnaissance.
+    - **Usage:**
+      ```bash
+      echo "example.com" | waybackurls
+      ```
+- [GAU (Get All URLs)](https://github.com/lc/gau)
+    - GAU collects URLs from multiple public archives, including the Wayback Machine and Common Crawl.
+    - **Usage:**
+      ```bash
+      echo "example.com" | gau
+      ```
+- [Unfurl](https://github.com/tomnomnom/unfurl)
+    - Unfurl extracts subdomains, paths, and parameters from URLs for deeper analysis.
+    - **Usage:**
+      ```bash
+      echo "https://example.com/page?query=123" | unfurl
+      ```
 
 ### Port and Service Discovery
 

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -93,26 +93,26 @@ The list contains only tools that are freely available to download and use (alth
 - [Waybackurls](https://github.com/tomnomnom/waybackurls)
     - Waybackurls fetches all URLs known to the Wayback Machine for a given domain, useful for reconnaissance.
     - **Usage:**
-      
-      ```bash
-      waybackurls example.com
-      ```
+
+```bash
+waybackurls example.com
+```
 
 - [GAU (Get All URLs)](https://github.com/lc/gau)
     - GAU collects URLs from multiple public archives, including the Wayback Machine and Common Crawl.
     - **Usage:**
       
-      ```bash
-      gau example.com
-      ```
+```bash
+gau example.com
+```
 
 - [Unfurl](https://github.com/tomnomnom/unfurl)
     - Unfurl extracts subdomains, paths, and parameters from URLs for deeper analysis.
     - **Usage:**
       
-      ```bash
-      unfurl "https://example.com/page?query=123"
-      ```
+    ```bash
+    unfurl "https://example.com/page?query=123"
+    ```
 
 ### Port and Service Discovery
 

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -101,7 +101,7 @@ waybackurls example.com
 - [GAU (Get All URLs)](https://github.com/lc/gau)
     - GAU collects URLs from multiple public archives, including the Wayback Machine and Common Crawl.
     - **Usage:**
-      
+
 ```bash
 gau example.com
 ```
@@ -110,9 +110,9 @@ gau example.com
     - Unfurl extracts subdomains, paths, and parameters from URLs for deeper analysis.
     - **Usage:**
       
-    ```bash
-    unfurl "https://example.com/page?query=123"
-    ```
+```bash
+unfurl "https://example.com/page?query=123"
+```
 
 ### Port and Service Discovery
 

--- a/document/6-Appendix/A-Testing_Tools_Resource.md
+++ b/document/6-Appendix/A-Testing_Tools_Resource.md
@@ -93,20 +93,25 @@ The list contains only tools that are freely available to download and use (alth
 - [Waybackurls](https://github.com/tomnomnom/waybackurls)
     - Waybackurls fetches all URLs known to the Wayback Machine for a given domain, useful for reconnaissance.
     - **Usage:**
+      
       ```bash
-      echo "example.com" | waybackurls
+      waybackurls example.com
       ```
+
 - [GAU (Get All URLs)](https://github.com/lc/gau)
     - GAU collects URLs from multiple public archives, including the Wayback Machine and Common Crawl.
     - **Usage:**
+      
       ```bash
-      echo "example.com" | gau
+      gau example.com
       ```
+
 - [Unfurl](https://github.com/tomnomnom/unfurl)
     - Unfurl extracts subdomains, paths, and parameters from URLs for deeper analysis.
     - **Usage:**
+      
       ```bash
-      echo "https://example.com/page?query=123" | unfurl
+      unfurl "https://example.com/page?query=123"
       ```
 
 ### Port and Service Discovery


### PR DESCRIPTION
### Added modern reconnaissance tools (Waybackurls, GAU, Unfurl) to Content Discovery section  

This PR covers issue #1058.  

- [x] This PR handles the issue and requires no additional PRs.  
- [x] You have validated the need for this change.  

**What did this PR accomplish?**  

- Added `Waybackurls`, `GAU`, and `Unfurl` to the **Content Discovery** section.  
- Updated the Testing Tools Resource with modern tools used for reconnaissance.  

Thank you for your contribution! 🚀
