### PR TITLE
Add Turkish translation reference

### DIFF
--- a/.github/configs/.markdownlint.json
+++ b/.github/configs/.markdownlint.json
@@ -5,5 +5,6 @@
   "MD024": { "siblings_only": true},
   "MD026": { "punctuation" : ".,;:!。，；：!" },
   "line-length": false,
+  "descriptive-link-text": false,
   "code-block-style": { "style" : "fenced" }
 }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can also join our [Google Group](https://groups.google.com/a/owasp.org/forum
 - [Russian](https://github.com/andrettv/WSTG/tree/master/WSTG-ru)
 - [French](https://github.com/clallier94/wstg-translation-fr)
 - [Persian (Farsi)](https://github.com/whoismh11/owasp-wstg-fa)
+- [Turkish](https://github.com/enoskom/Owasp-wstg)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ You can also join our [Google Group](https://groups.google.com/a/owasp.org/forum
 
 - [Portuguese-BR](https://github.com/doverh/wstg-translations-pt)
 - [Russian](https://github.com/andrettv/WSTG/tree/master/WSTG-ru)
-- [French](https://github.com/clallier94/wstg-translation-fr)
 - [Persian (Farsi)](https://github.com/whoismh11/owasp-wstg-fa)
 - [Turkish](https://github.com/enoskom/Owasp-wstg)
 


### PR DESCRIPTION
This PR:
- Fixes OWASP/wstg#1208.
- Reverts the fix for OWASP/wstg#1007 (as that repo is now 404).
- Disables MD059 which is/was newer than out MD Lint config.

* [x] This PR handles the issue and requires no additional PRs.
* [x] You have validated the need for this change.
