### PR TITLE
Remove duplicate entry from checklist.json

### DIFF
--- a/checklists/checklist.json
+++ b/checklists/checklist.json
@@ -624,14 +624,7 @@
                   ]
                 }
                 ,{
-                "name":"Testing for Buffer Overflow",
-                "id":"WSTG-INPV-13",
-                "reference":"https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Buffer_Overflow",
-                "objectives":[
-                    ""
-                  ]
-                }
-                ,{
+                
                 "name":"Testing for Format String Injection",
                 "id":"WSTG-INPV-13",
                 "reference":"https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection",


### PR DESCRIPTION
This PR removes a duplicate entry for WSTG-INPV-13(Testing for Buffer Overflow) from checklist.json.

Ensures no duplicate test IDs are present.

Keeps the checklist consistent and aligned with the OWASP Web Security Testing Guide.

Checklist:

This PR handles the issue and requires no additional PRs.
The change has been validated  as necessary.

Happy to adjust if needed. Thank you for reviewing!