### PR TITLE
Add reference to CWE-1428 in WSTG-CRYP-01 (Weak TLS)

### DIFF
--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
@@ -123,3 +123,4 @@ It can also be possible to performed limited testing using a web browser, as mod
 
 - [OWASP Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)
 - [Mozilla Server-Side TLS Guide](https://wiki.mozilla.org/Security/Server_Side_TLS)
+- [CWE-1428: Reliance on HTTP instead of HTTPS](https://cwe.mitre.org/data/definitions/1428.html)


### PR DESCRIPTION
Hi Team,

Added:
-  `CWE-1428: Reliance on HTTP instead of HTTPS` - as this is a relatively new CWE record (from the 2025y); so it is missing now (references section).

This PR fixes OWASP/wstg#1241

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Added a reference to [CWE-1428: Reliance on HTTP instead of HTTPS](https://cwe.mitre.org/data/definitions/1428.html) in WSTG-CRYP-01.
- Improved CWE mapping for transport layer security weaknesses (e.g., mixed content, HTTP redirects, unencrypted channels) in this way.

