### PR TITLE
Update cached content section to reflect Google cache removal

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
@@ -64,7 +64,23 @@ site:owasp.org
 
 To search for content that has previously been indexed, use the `cache:` operator. This is helpful for viewing content that may have changed since the time it was indexed, or that may no longer be available. Not all search engines provide cached content to search; the most useful source at time of writing is Google.
 
-To view `owasp.org` as it is cached, the syntax is:
+
+
+#### Internet Archive Wayback Machine
+
+The [Internet Archive Wayback Machine](https://archive.org/web/) is the most comprehensive tool for viewing historical snapshots of web pages. It maintains an extensive archive of web pages dating back to 1996.
+
+To view archived versions of a site, visit `https://web.archive.org/web/*/` followed by the target URL:
+
+```text
+https://web.archive.org/web/*/owasp.org
+```
+
+This will display a calendar view showing all available snapshots of the site over time.
+
+#### Bing Cache
+
+Bing still provides cached versions of web pages. To view cached content, use the `cache:` operator:
 
 ```text
 cache:owasp.org
@@ -72,6 +88,15 @@ cache:owasp.org
 
 ![Google Cache Operation Search Result Example](images/Google_cache_Operator_Search_Results_Example_20200406.png)\
 *Figure 4.1.1-2: Google Cache Operation Search Result Example*
+
+Alternatively, click the arrow next to search results in Bing and select "Cached" from the dropdown menu.
+
+#### Other Cached Content Services
+
+Additional services for viewing cached or archived web pages include:
+
+- [archive.today](https://archive.today/) (also known as archive.is) - On-demand archiving service that creates permanent snapshots
+- [CachedView](https://cachedview.com/) - Aggregates cached pages from multiple sources including Google Cache historical data, Wayback Machine, and others
 
 ### Google Hacking or Dorking
 


### PR DESCRIPTION
This PR covers issue #1253  .

- [ ] This PR handles the issue and requires no additional PRs.
- [ ] You have validated the need for this change.

**What did this PR accomplish?**

- Updated the "Viewing Cached Content" section to reflect Google's removal of cache functionality in September 2024
- Promoted Internet Archive Wayback Machine as the primary tool for viewing cached/archived content with detailed usage    instructions
- Added Bing Cache as a working alternative that still supports the cache: operator
- Included additional cached content services (archive.today and CachedView) to provide comprehensive alternatives
- Maintained the importance of cached content viewing for security testing while updating with current, working tools

Thank you for your contribution!