### PR TITLE
Address Google cache no longer available

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage.md
@@ -69,6 +69,7 @@ To view `owasp.org` as it is cached, the syntax is:
 ```text
 cache:owasp.org
 ```
+
 ![Google Cache Operation Search Result Example](images/Google_cache_Operator_Search_Results_Example_20200406.png)\
 *Figure 4.1.1-2: Google Cache Operation Search Result Example*
 


### PR DESCRIPTION
This PR is related to #1253.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Promoted Internet Archive Wayback Machine as the primary tool for viewing cached/archived content with detailed usage instructions
- Added Bing Cache as a working alternative that still supports the cache: operator
- Included additional cached content services (archive.today and CachedView) to provide comprehensive alternatives
- Maintained the importance of cached content viewing for security testing while updating with current, working tools
- Fixed few typos while editing the file 
Thank you for your contribution!