### PR TITLE
Fix incorrect terminology

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server.md
@@ -100,7 +100,7 @@ Testers can use this information to guess that the obscured server is nginx. How
 
 Web servers may be identified by examining their error responses, and in the cases where they have not been customized, their default error pages. One way to compel a server to present these is by sending intentionally incorrect or malformed requests.
 
-For example, here is the response to a request for the non-existent method `SANTA CLAUS` from an Apache server.
+For example, here is the response to a request for the non-existent HTTP version `SANTA CLAUS` from an Apache server.
 
 ```sh
 GET / SANTA CLAUS/1.1


### PR DESCRIPTION
This PR fixes #1259.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Change terminology used from `method` to `HTTP version`