### PR TITLE
security: scope PR write permissions to job level in comment workflow

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   comment:
-     permissions:
-        contents: read
-           pull-requests: write
+    permissions:
+     contents: read
+     pull-requests: write
+         
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:


### PR DESCRIPTION
Scopes pull-requests: write permissions to the job level in the comment
workflow to follow GitHub Actions least-privilege guidance and reduce
risk when handling PR artifacts.

No functional behavior changes.