### PR TITLE
Add JSON Parameter Pollution example

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
@@ -93,6 +93,18 @@ Append the same parameter with a different value:
 https://example.com/?mode=guest&search_string=kittens&num_results=100&search_string=puppies
 ```
 
+For JSON-based endpoints, the payload would look like this:
+
+```http
+POST /search HTTP/1.1
+Host: example.com
+Content-Type: application/json
+
+{
+  "search_string": "kittens",
+  "search_string": "puppies"
+}
+```
 and submit the new request.
 
 Analyze the response page to determine which value(s) were parsed. In the above example, the search results may show `kittens`, `puppies`, some combination of both (`kittens,puppies` or `kittens~puppies` or `['kittens','puppies']`), may give an empty result, or error page.


### PR DESCRIPTION
Added a JSON payload example to the Server-Side HPP section to demonstrate how to test modern REST APIs. Kept the context consistent with the existing search_string example.

- [x] You have validated the need for this change.

**What did this PR accomplish?**
- Added a JSON request example to the "Server-Side HPP" section.
- Modernized the guide to include REST API testing scenarios (POST with JSON body).