### PR TITLE
Add Key ID (kid) manipulation injection vectors to JWT testing

### DIFF
--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md
@@ -201,7 +201,8 @@ For example, an attacker can modify the header to point to an empty file:
 
 Since the content of `/dev/null` is empty, the attacker can then sign the malicious token using an **empty string** as the secret key. If the server is vulnerable, it will read the empty file, use the empty string to verify the signature, and accept the forged token.
 
-**Command/SQL Injection:**
+#### Command/SQL Injection
+
 If the `kid` is passed unsanitized to a database query or a system command to retrieve the key, it may be vulnerable to SQL Injection or Command Injection.
 
 For example, an attacker can inject a SQL payload into the `kid` parameter to control the key returned by the database:


### PR DESCRIPTION
Added a new section on "Key ID (kid) Manipulation" to the JWT testing guide.

**Why is this change needed?**
The current guide covers algorithm confusion and weak keys but is missing specific test cases for `kid` header injection. Specifically, Directory Traversal (via `/dev/null`) and SQL Injection via the `kid` parameter are common high-impact vulnerabilities in modern JWT implementations.

**What did this PR accomplish?**
- Added explanation of `kid` directory traversal vectors.
- Added a JSON payload example for the `/dev/null` signing bypass.
- Added a dedicated section and JSON payload example for SQL Injection via `kid`.