### PR TITLE
Add 202 as alive for link check

### DIFF
--- a/.github/configs/markdown-link-check-config.json
+++ b/.github/configs/markdown-link-check-config.json
@@ -29,5 +29,9 @@
         "headers": {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:64.0) Gecko/20100101 Firefox/64.0"
         }
-    }]
+    }],
+    "aliveStatusCodes": [
+        200,
+        202
+    ]
 }


### PR DESCRIPTION
Fixes for example:
<img width="951" height="313" alt="image" src="https://github.com/user-attachments/assets/a9777815-dfdc-4daa-b4ee-04458afffce4" />

