### PR TITLE
fix: Remove duplicate WSTG-INPV-13 Buffer Overflow entry (fixes #1165)

### DIFF
--- a/checklists/checklist.json
+++ b/checklists/checklist.json
@@ -624,15 +624,8 @@
                     "Bypass special characters and OS commands filter."
                   ]
                 }
-                ,{
-                "name":"Testing for Buffer Overflow",
-                "id":"WSTG-INPV-13",
-                "reference":"https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Buffer_Overflow",
-                "objectives":[
-                    ""
-                  ]
-                }
-                ,{
+                ,
+                {
                 "name":"Testing for Format String Injection",
                 "id":"WSTG-INPV-13",
                 "reference":"https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection",


### PR DESCRIPTION
This PR covers issue #1165.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Removed duplicate WSTG-INPV-13 entry ("Testing for Buffer Overflow") from checklist.json
- The Buffer Overflow test was deprecated and removed from WSTG, but its checklist entry remained, creating a duplicate ID conflict with "Testing for Format String Injection"
