### PR TITLE
Add archive symlink attack testing technique to WSTG-BUSL-09

### DIFF
--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files.md
@@ -149,7 +149,6 @@ If the backend extracts this archive without validating or rejecting symbolic li
 1. Create an archive: `tar -czf malicious.tar.gz link.txt`
 1. Upload the archive to the application.
 1. Check:
-
    - Is the symbolic link extracted?
    - Does the application follow the link?
    - Can sensitive file contents be accessed?


### PR DESCRIPTION
This PR fixes #991.

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Added a new subsection titled "Archive Symlink Attacks" under WSTG-BUSL-09.
- Documented the attack description, testing methodology, and impact.

Closes #991 