### PR TITLE
Fix formatting in .textlintrc configuration

### DIFF
--- a/.github/configs/.textlintrc
+++ b/.github/configs/.textlintrc
@@ -568,7 +568,7 @@
 				[
 					"utilising",
 					"utilizing"
-				]
+				],
 				[
 					"worldlist(s)?",
 					"wordlist$1"


### PR DESCRIPTION
This pull request makes a minor edit to the `.github/configs/.textlintrc` file, correcting the punctuation in the list of word replacements. The change ensures proper formatting for the configuration file.