### PR TITLE
PR for #734 and updating cryptographic recommendations for TLS usage

### DIFF
--- a/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
+++ b/document/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security.md
@@ -65,7 +65,7 @@ As well as being cryptographically secure, the certificate must also be consider
 
 - Be within the defined validity period.
     - Any certificates issued after 1st September 2020 must not have a maximum lifespan of more than [398 days](https://blog.mozilla.org/security/2020/07/09/reducing-tls-certificate-lifespans-to-398-days/).
-    - The validity period of certificates will gradually be reduced to a maximum lifespan of [47 days until March 2029](https://github.com/cabforum/servercert/blob/main/docs/BR.md#11-overview).
+    - The validity period of certificates will gradually be reduced to a maximum lifespan of [47 days in March 2029](https://github.com/cabforum/servercert/blob/main/docs/BR.md#11-overview).
 - Be signed by a trusted certificate authority (CA).
     - This should either be a trusted public CA for externally facing applications, or an internal CA for internal applications.
     - Don't flag internal applications as having untrusted certificates just because *your* system doesn't trust the CA.


### PR DESCRIPTION
This PR covers issue #734 .

- [ ] This PR handles the issue and requires no additional PRs. (It doesn't because refactoring the cryptoprimitives is probably best done as a multi-stage job. There's a few files I'd like to go over step by step - unless you want to tidy it up into one neat PR that is)
- [X] You have validated the need for this change.

**What did this PR accomplish?**
I started of small with a first minor patch set to fix some inaccuracies within the TLS recommendations.
I updated it to:
- Mention TLS 1.3 should be preferred over 1.2
- Use the correct lingo when talking about security of protocols
- Fix the error that SHA-256 is not a signature algorithm
- Add current recommendations for secure algorithms
- Add a section about post-quantum and hybrid algorithm recommendations

On top of that, I have a second commit f59b642 that adds a small change to certificate lifespan recommendations. 
I thought it best to include this minor addition here since I was already dealing with the file and it fits thematically with certificate security. If you want I can open a separate issue/PR to include that change.

I'm open for discussion if anybody wants to chip in about the recommendations I listed or if anybody disagrees. Those changes are based upon NIST recommendation guidelines and current industry practices so I feel confident they are correct.
Otherwise if you want me to change anything else, feel free to mention it. It's my first PR here so if I missed something in the contributor guide I'm willing to correct it.