### PR TITLE
Add Testing for Cross-Device Session Reuse and Single Authentication Cookie in SSO Environments [WSTG-SESS-06]

### DIFF
--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -128,9 +128,9 @@ Expected Result:
 Security Implications
 If an SSO implementation:
 
-- Relies primarily on a single authentication cookie,
-- Allows that cookie to be reused across devices,
-- Does not revoke it server-side upon logout,
+- Relies primarily on a single authentication cookie
+- Allows that cookie to be reused across devices
+- Does not revoke it server-side upon logout
 
 then:
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -123,7 +123,6 @@ Expected Result:
 - Access must not remain valid until cookie expiration.
 - All applications trusting the SSO cookie must reject it.
 
-Security Implications
 If an SSO implementation:
 
 - Relies primarily on a single authentication cookie

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -87,10 +87,7 @@ Test Procedure:
 2. Intercept the authentication response.
 3. Record all cookies issued by the application or SSO domain.
 
-> Example:
-auth-cookie=XYZ123
-session_meta=ABC456
-tracking_id=DEF789
+For example: `auth-cookie=XYZ123`, `session_meta=ABC456`, `tracking_id=DEF789`...
 
 - Step 2 – Identify Authentication-Critical Cookie(s)
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -80,7 +80,9 @@ Testers should evaluate whether:
 - All applications trusting the SSO cookies reject it after logout.
 
 Test Procedure:
+
 - Step 1 – Authenticate and Capture All Issued Cookies
+
 1. Log in on Device 1 using valid credentials and complete MFA.
 2. Intercept the authentication response.
 3. Record all cookies issued by the application or SSO domain.
@@ -91,7 +93,9 @@ session_meta=ABC456
 tracking_id=DEF789
 
 - Step 2 – Identify Authentication-Critical Cookie(s)
+
 The purpose of this step is to determine whether the SSO implementation depends on a single authentication artifact.
+
 1. Send requests to protected endpoints.
 2. Remove cookies individually and resend the request.
 3. Observe which cookies are required to maintain a 200 OK response.
@@ -102,20 +106,24 @@ If only one cookie (e.g., auth-cookie) is required to sustain authentication, th
 When a single cookie represents the entire authenticated state, it becomes a high-value target. An attacker who obtains that cookie may not require any additional session metadata or device context to gain access.
 
 - Step 3 – Cross-Device Session Injection
+
 1. Copy the authentication-critical cookie value.
 2. Open a different browser or device (Device 2).
 3. Manually insert the copied single cookie.
 4. Attempt to access protected endpoints across:
+
 - The original application
 - Other applications participating in the same SSO ecosystem
 
 If Device 2 gains authenticated access without credential entry or MFA, the cookie is reusable across contexts.
 
 - Step 4 – Logout Validation Across Devices
+
 1. On Device 1, perform logout.
 2. On Device 2, refresh or access protected resources using the same injected cookie value.
 
 Expected Result:
+
 - Logout must invalidate the authentication cookie server-side.
 - All sessions using that cookie must be terminated.
 - Access must not remain valid until cookie expiration.
@@ -123,6 +131,7 @@ Expected Result:
 
 Security Implications
 If an SSO implementation:
+
 - Relies primarily on a single authentication cookie,
 - Allows that cookie to be reused across devices,
 - Does not revoke it server-side upon logout,

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -64,79 +64,79 @@ Perform a log out in the tested application. Verify if there is a central portal
 
 ### Testing Cross-Device Session Reuse and Single-Value Dependency in SSO
 
-> While traditional SSO logout testing focuses on reauthentication flows within the same browser context, testers must also evaluate whether authentication cookies can be replayed across devices.
+> While traditional SSO logout testing focuses on reauthentication flows within the same browser context, testers must also evaluate whether authentication artifact (e.g., cookie, header, or bearer token) can be replayed across devices.
 
-In some Single Sign-On (SSO) implementations, authentication across multiple applications relies on a single authentication cookie issued after successful login (e.g., after password and MFA verification).
+In some Single Sign-On (SSO) implementations, authentication across multiple applications relies on a single authentication artifact issued after successful login (e.g., after password and MFA verification).
 
-While this cookie may be marked Secure and HttpOnly, its security depends entirely on server-side validation and revocation controls. If the SSO ecosystem relies on a single cookie as the sole proof of authentication, compromise of that cookie may grant immediate cross-application access.
+> An example, while a cookie may be set with Secure and HttpOnly, its security depends entirely on server-side validation and revocation controls. If the SSO ecosystem relies on a single cookie as the sole proof of authentication, compromise of that cookie may grant immediate cross-application access.
 
 Testers should evaluate whether:
 
-- Only one cookie is required to maintain authenticated state.
-- The cookie can be reused across browsers or devices.
-- Logout properly invalidates the cookie server-side.
-- All applications trusting the SSO cookies reject it after logout.
+- If only single authentication artifact is required to maintain authenticated state.
+- The authentication artifact can be reused across browsers or devices.
+- Logout properly invalidates the authentication artifact server-side.
+- All applications trusting the SSO authentication artifact reject it after logout.
 
 Test Procedure:
 
-- Step 1 – Authenticate and Capture All Issued Cookies
+- Step 1 – Authenticate and Capture All Issued Authentication Artifact
 
 1. Log in on Device 1 using valid credentials and complete MFA.
 2. Intercept the authentication response.
-3. Record all cookies issued by the application or SSO domain.
+3. Record all authentication artifact (e.g., cookie, header, or bearer token) issued by the application or SSO domain.
 
 For example: `auth-cookie=XYZ123`, `session_meta=ABC456`, `tracking_id=DEF789`...
 
-- Step 2 – Identify Authentication-Critical Token(s)
+- Step 2 – Identify Authentication-Critical Artifact(s)
 
 The purpose of this step is to determine whether the SSO implementation depends on a single authentication artifact (e.g., cookie, header, or bearer token).
 
 1. Send requests to protected endpoints.
-2. Remove session tokens individually and resend the request.
-3. Observe which tokens are required to maintain a 200 OK response.
+2. Remove authentication artifact individually and resend the request.
+3. Observe which are required to maintain a 200 OK response.
 
-If only one token (e.g., auth-cookie) is required to sustain authentication, this indicates that the SSO trust boundary may rely solely on that token.
+If only one authentication artifact (e.g., auth-cookie) is required to sustain authentication, this indicates that the SSO trust boundary may rely solely on that single-value.
 
 > Security Note:
-When a single authentication token represents the entire authenticated state, it becomes a high-value target. An attacker who obtains that token may not require any additional session metadata or device context to gain access.
+When a single authentication artifact represents the entire authenticated state, it becomes a high-value target. An attacker who obtains that single-value may not require any additional session metadata or device context to gain access.
 
 - Step 3 – Cross-Device Session Injection
 
-1. Copy the authentication-critical cookie value.
+1. Copy the authentication-critical artifact value (e.g., auth-cookie=XYZ123).
 2. Open a different browser or device (Device 2).
-3. Manually insert the copied single cookie.
+3. Manually insert the copied single artifact.
 4. Attempt to access protected endpoints across:
     - The original application
     - Other applications participating in the same SSO ecosystem
 
-If Device 2 gains authenticated access without credential entry or MFA, the cookie is reusable across contexts.
+If Device 2 gains authenticated access without credential entry or MFA, the artifact is reusable across contexts.
 
 - Step 4 – Logout Validation Across Devices
 
 1. On Device 1, perform logout.
-2. On Device 2, refresh or access protected resources using the same injected cookie value.
+2. On Device 2, refresh or access protected resources using the same injected authenticaton artifact value.
 
 Expected Result:
 
-- Logout must invalidate the authentication cookie server-side.
-- All sessions using that cookie must be terminated.
-- Access must not remain valid until cookie expiration.
-- All applications trusting the SSO cookie must reject it.
+- Logout must invalidate the authentication artifact (e.g., cookie or bearer token) server-side.
+- All sessions using that artifact must be terminated.
+- Access must not remain valid until authentication artifact expiration.
+- All applications trusting the SSO authentication artifact must reject it.
 
 If an SSO implementation:
 
-- Relies primarily on a single authentication cookie
-- Allows that cookie to be reused across devices
+- Relies primarily on a single authentication artifact
+- Allows that artifact to be reused across devices
 - Does not revoke it server-side upon logout
 
 then:
 
-- Theft of that single cookie may immediately compromise active sessions.
+- Theft of that single-value authentication artifact may immediately compromise active sessions.
 - MFA protections are effectively bypassed after initial login.
 - Logout may not provide global session termination.
-- Access may persist for the entire cookie lifetime (e.g., 8 hours).
+- Access may persist for the entire artifact lifetime (e.g., auth-cookie=XYZ123; max-age=28800, 8 hours).
 
-Implementations should avoid architectures where a single cookie represents the entire authenticated state without additional validation controls.
+Implementations should avoid architectures where a single-value authentication artifact represents the entire authenticated state without additional validation controls.
 
 ## Tools
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -64,7 +64,6 @@ Perform a log out in the tested application. Verify if there is a central portal
 
 ### Testing for Cross-Device Session Reuse and Single Authentication Cookie in Single Sign-On Environments
 
-
 > While traditional SSO logout testing focuses on reauthentication flows within the same browser context, testers must also evaluate whether authentication cookies can be replayed across devices.
 
 In some Single Sign-On (SSO) implementations, authentication across multiple applications relies on a single authentication cookie issued after successful login (e.g., after password and MFA verification).

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -62,7 +62,7 @@ Perform a log out in the tested application. Verify if there is a central portal
 
 > It is expected that the invocation of a log out function in a web application connected to a SSO system or in the SSO system itself causes global termination of all sessions. An authentication of the user should be required to gain access to the application after log out in the SSO system and connected application.
 
-### Testing for Cross-Device Session Reuse and Single Authentication Cookie in Single Sign-On Environments
+### Testing Cross-Device Session Reuse and Single-Value Dependency in SSO
 
 > While traditional SSO logout testing focuses on reauthentication flows within the same browser context, testers must also evaluate whether authentication cookies can be replayed across devices.
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -62,11 +62,87 @@ Perform a log out in the tested application. Verify if there is a central portal
 
 > It is expected that the invocation of a log out function in a web application connected to a SSO system or in the SSO system itself causes global termination of all sessions. An authentication of the user should be required to gain access to the application after log out in the SSO system and connected application.
 
+### Testing for Cross-Device Session Reuse and Single Authentication Cookie in Single Sign-On Environments
+
+Cross-Device Session Reuse and Single-Cookie Dependency in SSO Implementations
+
+> While traditional SSO logout testing focuses on reauthentication flows within the same browser context, testers must also evaluate whether authentication cookies can be replayed across devices.
+
+In some Single Sign-On (SSO) implementations, authentication across multiple applications relies on a single authentication cookie issued after successful login (e.g., after password and MFA verification).
+
+While this cookie may be marked Secure and HttpOnly, its security depends entirely on server-side validation and revocation controls. If the SSO ecosystem relies on a single cookie as the sole proof of authentication, compromise of that cookie may grant immediate cross-application access.
+
+Testers should evaluate whether:
+
+- Only one cookie is required to maintain authenticated state.
+- The cookie can be reused across browsers or devices.
+- Logout properly invalidates the cookie server-side.
+- All applications trusting the SSO cookies reject it after logout.
+
+Test Procedure:
+- Step 1 – Authenticate and Capture All Issued Cookies
+1. Log in on Device 1 using valid credentials and complete MFA.
+2. Intercept the authentication response.
+3. Record all cookies issued by the application or SSO domain.
+
+> Example:
+auth-cookie=XYZ123
+session_meta=ABC456
+tracking_id=DEF789
+
+- Step 2 – Identify Authentication-Critical Cookie(s)
+The purpose of this step is to determine whether the SSO implementation depends on a single authentication artifact.
+1. Send requests to protected endpoints.
+2. Remove cookies individually and resend the request.
+3. Observe which cookies are required to maintain a 200 OK response.
+
+If only one cookie (e.g., auth-cookie) is required to sustain authentication, this indicates that the SSO trust boundary may rely solely on that cookie.
+
+> Security Note:
+When a single cookie represents the entire authenticated state, it becomes a high-value target. An attacker who obtains that cookie may not require any additional session metadata or device context to gain access.
+
+- Step 3 – Cross-Device Session Injection
+1. Copy the authentication-critical cookie value.
+2. Open a different browser or device (Device 2).
+3. Manually insert the copied single cookie.
+4. Attempt to access protected endpoints across:
+- The original application
+- Other applications participating in the same SSO ecosystem
+
+If Device 2 gains authenticated access without credential entry or MFA, the cookie is reusable across contexts.
+
+- Step 4 – Logout Validation Across Devices
+1. On Device 1, perform logout.
+2. On Device 2, refresh or access protected resources using the same injected cookie value.
+
+Expected Result:
+- Logout must invalidate the authentication cookie server-side.
+- All sessions using that cookie must be terminated.
+- Access must not remain valid until cookie expiration.
+- All applications trusting the SSO cookie must reject it.
+
+Security Implications
+If an SSO implementation:
+- Relies primarily on a single authentication cookie,
+- Allows that cookie to be reused across devices,
+- Does not revoke it server-side upon logout,
+
+then:
+
+- Theft of that single cookie may immediately compromise active sessions.
+- MFA protections are effectively bypassed after initial login.
+- Logout may not provide global session termination.
+- Access may persist for the entire cookie lifetime (e.g., 8 hours).
+
+Implementations should avoid architectures where a single cookie represents the entire authenticated state without additional validation controls.
+
 ## Tools
 
 - [Burp Suite - Repeater](https://portswigger.net/burp/documentation/desktop/tools/repeater)
 
 ## References
+
+- [The Golden Cookie: When SSO Session Boundaries Fail](https://allaboutinfosec.blogspot.com/2026/03/the-golden-cookie-when-sso-session.html)
 
 ### Whitepapers
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -87,18 +87,18 @@ Test Procedure:
 
 For example: `auth-cookie=XYZ123`, `session_meta=ABC456`, `tracking_id=DEF789`...
 
-- Step 2 – Identify Authentication-Critical Cookie(s)
+- Step 2 – Identify Authentication-Critical Token(s)
 
-The purpose of this step is to determine whether the SSO implementation depends on a single authentication artifact.
+The purpose of this step is to determine whether the SSO implementation depends on a single authentication artifact (e.g., cookie, header, or bearer token).
 
 1. Send requests to protected endpoints.
-2. Remove cookies individually and resend the request.
-3. Observe which cookies are required to maintain a 200 OK response.
+2. Remove session tokens individually and resend the request.
+3. Observe which tokens are required to maintain a 200 OK response.
 
-If only one cookie (e.g., auth-cookie) is required to sustain authentication, this indicates that the SSO trust boundary may rely solely on that cookie.
+If only one token (e.g., auth-cookie) is required to sustain authentication, this indicates that the SSO trust boundary may rely solely on that token.
 
 > Security Note:
-When a single cookie represents the entire authenticated state, it becomes a high-value target. An attacker who obtains that cookie may not require any additional session metadata or device context to gain access.
+When a single authentication token represents the entire authenticated state, it becomes a high-value target. An attacker who obtains that token may not require any additional session metadata or device context to gain access.
 
 - Step 3 – Cross-Device Session Injection
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -64,7 +64,6 @@ Perform a log out in the tested application. Verify if there is a central portal
 
 ### Testing for Cross-Device Session Reuse and Single Authentication Cookie in Single Sign-On Environments
 
-Cross-Device Session Reuse and Single-Cookie Dependency in SSO Implementations
 
 > While traditional SSO logout testing focuses on reauthentication flows within the same browser context, testers must also evaluate whether authentication cookies can be replayed across devices.
 

--- a/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
+++ b/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality.md
@@ -108,9 +108,8 @@ When a single cookie represents the entire authenticated state, it becomes a hig
 2. Open a different browser or device (Device 2).
 3. Manually insert the copied single cookie.
 4. Attempt to access protected endpoints across:
-
-- The original application
-- Other applications participating in the same SSO ecosystem
+    - The original application
+    - Other applications participating in the same SSO ecosystem
 
 If Device 2 gains authenticated access without credential entry or MFA, the cookie is reusable across contexts.
 


### PR DESCRIPTION
This PR covers issue #1377

- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.

**What did this PR accomplish?**

- Adds a new test case under **WSTG-SESS-06 (Testing for Logout Functionality)** to cover cross-device session reuse in Single Sign-On (SSO) environments  
- Extends existing SSO guidance by introducing validation of **single authentication cookie dependency**  
- Provides a structured methodology to identify authentication-critical cookies and assess whether a single token represents the entire authenticated state  
- Introduces testing steps for **cross-device token replay** and verification of **server-side invalidation upon logout**  
- Highlights scenarios where logout does not terminate all sessions due to lack of centralized token revocation  

This change is strictly additive and does not modify the existing SSO guidance under **"Testing for Session Termination in Single Sign-On Environments (Single Sign-Off)"**.  

It complements current guidance by addressing token lifecycle and reuse patterns commonly observed in modern SSO implementations, particularly where a single cookie is trusted across multiple applications.

The addition is informed by real-world testing scenarios and aims to improve coverage for session termination and token revocation validation.

Thank you for your contribution!
