### PR TITLE
Fix typo

### DIFF
--- a/document/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging.md
+++ b/document/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging.md
@@ -39,7 +39,7 @@ function handler(event) {
 
 ### Origin Security
 
-The origin is made up of a scheme, host name, and port. It uniquely identifies the domain sending or receiving the message, and does not include the path or the fragment part of the URL. For instance, `https://example.com` will be considered different from `http://example.com` because the scheme of the former is `https`, while the latter is `http`. This also applies to web servers running in the same domain but on different ports.
+The origin is made up of a scheme, hostname, and port. It uniquely identifies the domain sending or receiving the message, and does not include the path or the fragment part of the URL. For instance, `https://example.com` will be considered different from `http://example.com` because the scheme of the former is `https`, while the latter is `http`. This also applies to web servers running in the same domain but on different ports.
 
 ## Test Objectives
 

--- a/document/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging.md
+++ b/document/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging.md
@@ -39,7 +39,7 @@ function handler(event) {
 
 ### Origin Security
 
-The origin is made up of a scheme, host name, and port. It uniquely identifies the domain sending or receiving the message, and does not include the path or the fragment part of the URL. For instance, `https://example.com` will be considered different from `http://example.com` because the schema of the former is `https`, while the latter is `http`. This also applies to web servers running in the same domain but on different ports.
+The origin is made up of a scheme, host name, and port. It uniquely identifies the domain sending or receiving the message, and does not include the path or the fragment part of the URL. For instance, `https://example.com` will be considered different from `http://example.com` because the scheme of the former is `https`, while the latter is `http`. This also applies to web servers running in the same domain but on different ports.
 
 ## Test Objectives
 


### PR DESCRIPTION
Typo fix, per: https://github.com/OWASP/www-project-web-security-testing-guide/pull/458

Former/latter ref seems correct already.