### PR TITLE
Update checklist generation/enrichment

### DIFF
--- a/.github/json/scripts/generate_checklist_json.py
+++ b/.github/json/scripts/generate_checklist_json.py
@@ -8,7 +8,7 @@ import sys
 import time
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -31,6 +31,24 @@ OPENCRE_LOOKUP_DESCRIPTION = (
 )
 CRE_IDS_CELL_MAX_LEN = 240
 DEFAULT_CONCURRENCY_LIMIT = 4
+
+# ``cre_ids`` / OpenCRE markdown reports use emoji below. Consoles and dark-themed
+# editors may use fonts or themes where some characters render monochrome, missing,
+# or low contrast; GitHub's job summary / web UI often differs.
+#
+# Unicode variation selector-16 (U+FE0F): prefer emoji-style (often colored) glyphs over
+# text-style symbols where the code point supports both presentations.
+EMOJI_PRESENTATION_SELECTOR = "\uFE0F"
+
+# Single map for ``cre_ids`` report emoji (delta bullets, headings, status column, legend).
+_CRE_REPORT_EMOJI: dict[str, str] = {
+    "Added": f"\u2795{EMOJI_PRESENTATION_SELECTOR}",  # ➕
+    "Removed": f"\u2796{EMOJI_PRESENTATION_SELECTOR}",  # ➖
+    "Updated": "\U0001F504",  # 🔄
+    "Unchanged": f"\u2705{EMOJI_PRESENTATION_SELECTOR}",  # ✅
+    "No mapping": "\U0001F6AB",  # 🚫
+    "New": "\U0001F195",  # 🆕
+}
 RETRY_COUNT = 3
 REQUEST_TIMEOUT = 30
 
@@ -69,6 +87,10 @@ def emit_markdown_report(text: str) -> None:
 class OpenCRELookupError(Exception):
     """Raised when an OpenCRE request cannot be resolved."""
 
+    def __init__(self, message: str, *, http_status: int | None = None) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+
 
 def fetch_json_with_retry(url: str, retries: int = RETRY_COUNT) -> dict[str, Any]:
     for attempt in range(retries):
@@ -90,26 +112,37 @@ def fetch_json_with_retry(url: str, retries: int = RETRY_COUNT) -> dict[str, Any
 
         except HTTPError as e:
             if e.code == 404:
-                raise OpenCRELookupError(f"OpenCRE returned 404 for {url}") from e
+                raise OpenCRELookupError(
+                    f"OpenCRE returned HTTP {e.code} for {url}", http_status=e.code
+                ) from e
 
             if attempt == retries - 1:
-                raise
+                raise OpenCRELookupError(
+                    f"OpenCRE returned HTTP {e.code} for {url}", http_status=e.code
+                ) from e
 
             time.sleep(2**attempt)
 
         except URLError as e:
             if attempt == retries - 1:
-                raise OpenCRELookupError(f"OpenCRE request failed for {url}: {e}") from e
+                raise OpenCRELookupError(
+                    f"OpenCRE request failed for {url}: {e}", http_status=None
+                ) from e
 
             time.sleep(2**attempt)
 
         except Exception as e:
             if attempt == retries - 1:
-                raise OpenCRELookupError(f"Unexpected error requesting {url}: {e}") from e
+                raise OpenCRELookupError(
+                    f"Unexpected error requesting {url}: {e}", http_status=None
+                ) from e
 
             time.sleep(2**attempt)
 
-    raise OpenCRELookupError(f"Failed to fetch OpenCRE data after {retries} attempts: {url}")
+    raise OpenCRELookupError(
+        f"Failed to fetch OpenCRE data after {retries} attempts: {url}",
+        http_status=None,
+    )
 
 
 def extract_cre_ids(data: dict[str, Any], section_id: str) -> list[str]:
@@ -146,6 +179,34 @@ def extract_cre_ids(data: dict[str, Any], section_id: str) -> list[str]:
     return list(dict.fromkeys(cre_ids))
 
 
+def _opencre_coerce_total_pages(raw: Any) -> tuple[int, bool]:
+    """
+    Parse OpenCRE ``total_pages`` for pagination. Returns ``(pages, used_fallback)``.
+
+    ``used_fallback`` is True when the value is ``None``, a ``bool``, a blank string
+    (after strip), not accepted by ``int(...)``, or ``int(...) < 1``.
+
+    Otherwise ``pages`` is ``int(...)`` with ``used_fallback`` False. That includes
+    positive ``int`` values, strings ``int`` parses (e.g. ``"2"``), and ``float`` values
+    (e.g. ``2.9`` truncates toward zero).
+    """
+    if raw is None:
+        return 1, True
+    if isinstance(raw, bool):
+        return 1, True
+    if isinstance(raw, str):
+        raw = raw.strip()
+        if raw == "":
+            return 1, True
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return 1, True
+    if n < 1:
+        return 1, True
+    return n, False
+
+
 def fetch_mapping(test_id: str) -> tuple[str, list[str]]:
     base_url = (
         f"{OPENCRE_BASE_URL}/{quote(OPENCRE_STANDARD, safe='')}"
@@ -155,9 +216,14 @@ def fetch_mapping(test_id: str) -> tuple[str, list[str]]:
     first_page = fetch_json_with_retry(base_url)
     all_cre_ids = extract_cre_ids(first_page, test_id)
 
-    total_pages = first_page.get("total_pages", 1)
-    if not isinstance(total_pages, int) or total_pages < 1:
-        total_pages = 1
+    raw_pages = first_page.get("total_pages", 1)
+    total_pages, pages_fallback = _opencre_coerce_total_pages(raw_pages)
+    if pages_fallback:
+        print(
+            f"WARNING: OpenCRE total_pages {raw_pages!r} for section {test_id!r} "
+            f"invalid or not a positive page count; using {total_pages} for pagination.",
+            file=sys.stderr,
+        )
 
     for page in range(2, total_pages + 1):
         paged_url = f"{base_url}&page={page}"
@@ -165,6 +231,36 @@ def fetch_mapping(test_id: str) -> tuple[str, list[str]]:
         all_cre_ids.extend(extract_cre_ids(page_data, test_id))
 
     return test_id, list(dict.fromkeys(all_cre_ids))
+
+
+def _cre_ids_map_from_categories(categories: dict[str, Any]) -> dict[str, list[str]]:
+    """
+    Build ``WSTG test id -> cre id list`` from a ``categories`` mapping (disk JSON or
+    in-memory checklist). Last occurrence of a duplicate id wins.
+    """
+    out: dict[str, list[str]] = {}
+    for category in categories.values():
+        if not isinstance(category, dict):
+            continue
+        tests = category.get("tests", [])
+        if not isinstance(tests, list):
+            continue
+        for test in tests:
+            if not isinstance(test, dict):
+                continue
+            test_id = test.get("id")
+            cre_ids = test.get("cre_ids")
+            if isinstance(test_id, str) and isinstance(cre_ids, list):
+                cleaned: list[str] = []
+                for cre_id in cre_ids:
+                    if not isinstance(cre_id, str):
+                        continue
+                    stripped = cre_id.strip()
+                    if not stripped:
+                        continue
+                    cleaned.append(stripped)
+                out[test_id] = cleaned
+    return out
 
 
 def load_existing_cre_ids(path: Path) -> dict[str, list[str]]:
@@ -181,94 +277,78 @@ def load_existing_cre_ids(path: Path) -> dict[str, list[str]]:
     if not isinstance(categories, dict):
         return {}
 
-    existing_cre_ids: dict[str, list[str]] = {}
+    return _cre_ids_map_from_categories(categories)
 
+
+def collect_cre_ids_by_test_id(checklist: OrderedDict) -> dict[str, list[str]]:
+    """
+    Normalized ``test id -> cre id list`` from an in-memory checklist.
+    If the same WSTG id appears more than once, the last occurrence wins.
+    """
+    categories = checklist.get("categories", {})
+    if not isinstance(categories, dict):
+        return {}
+    return _cre_ids_map_from_categories(categories)
+
+
+def _format_cre_ids_cell(cre_ids: list[str]) -> str:
+    joined = ", ".join(cre_ids)
+    if len(joined) > CRE_IDS_CELL_MAX_LEN:
+        return joined[: CRE_IDS_CELL_MAX_LEN - 1] + "…"
+    return joined
+
+
+def _sort_test_ids_guide_order(ids: Iterable[str], guide_rank: dict[str, int]) -> list[str]:
+    sentinel = len(guide_rank) + 1
+    return sorted(ids, key=lambda tid: (guide_rank.get(tid, sentinel), tid))
+
+
+def collect_test_names_by_id(checklist: OrderedDict) -> dict[str, str]:
+    """Last occurrence wins if the same WSTG id appears more than once."""
+    names: dict[str, str] = {}
+    categories = checklist.get("categories", {})
+    if not isinstance(categories, dict):
+        return names
     for category in categories.values():
         if not isinstance(category, dict):
             continue
-
         tests = category.get("tests", [])
         if not isinstance(tests, list):
             continue
-
         for test in tests:
             if not isinstance(test, dict):
                 continue
-
-            test_id = test.get("id")
-            cre_ids = test.get("cre_ids")
-            if isinstance(test_id, str) and isinstance(cre_ids, list):
-                existing_cre_ids[test_id] = [
-                    cre_id for cre_id in cre_ids if isinstance(cre_id, str)
-                ]
-
-    return existing_cre_ids
+            tid = test.get("id")
+            if not isinstance(tid, str):
+                continue
+            names[tid] = str(test.get("name", ""))
+    return names
 
 
-def _opencre_failure_is_404(message: str) -> bool:
-    return "404" in message
+def _cre_row_status(old: list[str], new: list[str]) -> str:
+    """
+    Machine status key comparing prior file vs after enrichment.
+    ``Unchanged`` = same non-empty mapping as before; ``No mapping`` = no ``cre_ids`` now
+    (including still-empty and cleared); ``New`` / ``Updated`` = mapping added or changed.
+    """
+    if old == new:
+        return "Unchanged" if old else "No mapping"
+    if not new:
+        return "No mapping"
+    if not old:
+        return "New"
+    return "Updated"
 
 
-def _opencre_failure_response_code(message: str) -> str:
-    """Best-effort HTTP status from OpenCRE error text; ``—`` when not present."""
-    m = re.search(r"returned (\d{3})\b", message)
-    if m:
-        return m.group(1)
-    if "404" in message:
-        return "404"
-    return "—"
+def _cre_status_display(status_key: str) -> str:
+    """Status cell / legend text with leading icon."""
+    icon = _CRE_REPORT_EMOJI.get(status_key, "\u2022")  # bullet fallback
+    return f"{icon} {status_key}"
 
 
-def _sort_opencre_failures_guide_order(
-    rows: list[tuple[str, str]], guide_rank: dict[str, int]
-) -> list[tuple[str, str]]:
-    """Order failures like the checklist (chapter order, then markdown file order)."""
-    sentinel = len(guide_rank) + 1
-    return sorted(
-        rows,
-        key=lambda r: (guide_rank.get(r[0], sentinel), r[0]),
-    )
-
-
-def _emit_opencre_failure_report(
-    failures: list[tuple[str, str]], guide_order_ids: list[str]
-) -> None:
-    if not failures:
-        return
-    guide_rank = {tid: i for i, tid in enumerate(guide_order_ids)}
-    lines: list[str] = [
-        "## Checklist JSON: OpenCRE lookup failures\n\n",
-        f"{OPENCRE_LOOKUP_DESCRIPTION}\n\n",
-        f"**{len(failures)}** WSTG test ID(s) could not be fetched from OpenCRE; "
-        "existing `cre_ids` in `checklist.json` are kept when present.\n\n",
-    ]
-    not_found = _sort_opencre_failures_guide_order(
-        [(tid, msg) for tid, msg in failures if _opencre_failure_is_404(msg)],
-        guide_rank,
-    )
-    other = _sort_opencre_failures_guide_order(
-        [(tid, msg) for tid, msg in failures if not _opencre_failure_is_404(msg)],
-        guide_rank,
-    )
-
-    def append_table(title: str, rows: list[tuple[str, str]]) -> None:
-        lines.append(f"### {title}\n\n")
-        if not rows:
-            lines.append("_None._\n\n")
-            return
-        lines.append("| WSTG ID | Response Code |\n")
-        lines.append("| --- | --- |\n")
-        for tid, msg in rows:
-            code = _opencre_failure_response_code(msg)
-            lines.append(f"| `{tid}` | {code} |\n")
-        lines.append("\n")
-
-    append_table(f"HTTP 404 ({len(not_found)})", not_found)
-    append_table(f"Other errors ({len(other)})", other)
-    emit_markdown_report("".join(lines))
-
-
-def enrich_with_opencre(checklist: OrderedDict) -> OrderedDict:
+def enrich_with_opencre(
+    checklist: OrderedDict,
+) -> tuple[OrderedDict, dict[str, list[str]], list[str], list[tuple[str, int | None, str]]]:
     all_tests = []
     existing_cre_ids = load_existing_cre_ids(OUTPUT_PATH)
 
@@ -291,7 +371,7 @@ def enrich_with_opencre(checklist: OrderedDict) -> OrderedDict:
     )
 
     results: dict[str, list[str] | None] = {}
-    failures: list[tuple[str, str]] = []
+    failures: list[tuple[str, int | None, str]] = []
 
     with ThreadPoolExecutor(max_workers=CONCURRENCY_LIMIT) as executor:
         futures = {
@@ -304,12 +384,12 @@ def enrich_with_opencre(checklist: OrderedDict) -> OrderedDict:
             try:
                 returned_id, cre_ids = future.result()
                 results[returned_id] = cre_ids
-            except Exception as exc:
-                message = str(exc)
+            except OpenCRELookupError as exc:
                 results[test_id] = None
-                failures.append((test_id, message))
-
-    _emit_opencre_failure_report(failures, unique_ids)
+                failures.append((test_id, exc.http_status, str(exc)))
+            except Exception as exc:
+                results[test_id] = None
+                failures.append((test_id, None, str(exc)))
 
     for test in all_tests:
         if not isinstance(test, dict):
@@ -332,7 +412,7 @@ def enrich_with_opencre(checklist: OrderedDict) -> OrderedDict:
         if test.get("cre_ids") != next_ids:
             test["cre_ids"] = next_ids
 
-    return checklist
+    return checklist, existing_cre_ids, unique_ids, failures
 
 
 def category_label_from_dirname(dirname: str) -> str | None:
@@ -507,61 +587,151 @@ def _write_empty_objectives_report(entries: list[tuple[str, str, str, str]]) -> 
     emit_markdown_report("".join(lines))
 
 
-def _cre_mapping_success_rows(
+def _cre_guide_status_table_rows(
     data: OrderedDict,
+    existing_cre_ids: dict[str, list[str]],
+    new_cre: dict[str, list[str]],
+    guide_order_ids: list[str],
 ) -> list[tuple[str, str, str, str]]:
-    """(category_label, test_id, test_name, cre_joined) for tests with non-empty cre_ids."""
+    """
+    One row per WSTG id in guide order: (test_id, name, status, cre_cell).
+    ``cre_cell`` is ``—`` when there are no ``cre_ids``.
+    """
+    names = collect_test_names_by_id(data)
     rows: list[tuple[str, str, str, str]] = []
-    categories = data.get("categories", {})
-    if not isinstance(categories, dict):
-        return rows
-    for category_label, category in categories.items():
-        if not isinstance(category, dict):
-            continue
-        tests = category.get("tests", [])
-        if not isinstance(tests, list):
-            continue
-        for test in tests:
-            if not isinstance(test, dict):
-                continue
-            cre_ids = test.get("cre_ids")
-            if not isinstance(cre_ids, list) or not cre_ids:
-                continue
-            parts = [str(x) for x in cre_ids if isinstance(x, str) and x]
-            if not parts:
-                continue
-            joined = ", ".join(parts)
-            if len(joined) > CRE_IDS_CELL_MAX_LEN:
-                joined = joined[: CRE_IDS_CELL_MAX_LEN - 1] + "…"
-            tid = test.get("id", "")
-            name = test.get("name", "")
-            if not isinstance(tid, str):
-                tid = str(tid)
-            if not isinstance(name, str):
-                name = str(name)
-            rows.append((str(category_label), tid, name, joined))
-    rows.sort(key=lambda r: (r[0], r[1]))
+    for tid in guide_order_ids:
+        old = existing_cre_ids.get(tid, [])
+        new = new_cre.get(tid, [])
+        status = _cre_row_status(old, new)
+        parts = [str(x) for x in new if isinstance(x, str) and x]
+        cre_cell = _format_cre_ids_cell(parts) if parts else "—"
+        rows.append((tid, names.get(tid, ""), status, cre_cell))
     return rows
 
 
-def _write_cre_mapping_success_report(data: OrderedDict) -> None:
-    rows = _cre_mapping_success_rows(data)
-    lines: list[str] = ["## Checklist JSON: OpenCRE mappings (success)\n\n"]
-    if not rows:
-        lines.append("No tests have non-empty `cre_ids` after this run.\n")
-        emit_markdown_report("".join(lines))
-        return
-    lines.append(
-        f"{OPENCRE_LOOKUP_DESCRIPTION}\n\n"
-        f"**{len(rows)}** checklist row(s) have at least one CRE id from OpenCRE.\n\n"
+def _write_cre_opencre_summary_report(
+    data: OrderedDict,
+    existing_cre_ids: dict[str, list[str]],
+    guide_order_ids: list[str],
+    opencre_failures: list[tuple[str, int | None, str]],
+) -> None:
+    """
+    One markdown section: ``cre_ids`` delta vs prior ``checklist.json`` plus a
+    per-test table in guide order (ID, name, status, CRE ids).
+    """
+    guide_rank = {tid: i for i, tid in enumerate(guide_order_ids)}
+    new_cre = collect_cre_ids_by_test_id(data)
+    all_ids = set(existing_cre_ids) | set(new_cre) | set(guide_order_ids)
+
+    added: list[str] = []
+    removed: list[str] = []
+    updated: list[str] = []
+    unchanged: list[str] = []
+    for tid in all_ids:
+        old = existing_cre_ids.get(tid, [])
+        new = new_cre.get(tid, [])
+        if old == new:
+            unchanged.append(tid)
+        elif not old and new:
+            added.append(tid)
+        elif old and not new:
+            removed.append(tid)
+        else:
+            updated.append(tid)
+
+    unchanged_mapped = sum(
+        1 for tid in unchanged if existing_cre_ids.get(tid, [])
     )
-    lines.append("| Category | ID | Name | CRE IDs |\n")
+    unchanged_no_mapping = len(unchanged) - unchanged_mapped
+
+    lines: list[str] = [
+        "## Checklist JSON: OpenCRE and `cre_ids`\n\n",
+        f"{OPENCRE_LOOKUP_DESCRIPTION}\n\n",
+    ]
+    if opencre_failures:
+        n404 = sum(1 for _tid, st, _m in opencre_failures if st == 404)
+        nother = len(opencre_failures) - n404
+        lines.append(
+            f"**OpenCRE:** {len(opencre_failures)} section lookup(s) failed "
+            f"({n404} HTTP 404, {nother} other). Prior `cre_ids` from `checklist.json` "
+            "were kept when present.\n\n"
+        )
+    lines.append("### Delta vs prior `checklist.json`\n\n")
+    if not existing_cre_ids and not OUTPUT_PATH.exists():
+        lines.append(
+            f"Prior baseline had no stored `cre_ids` (`{OUTPUT_PATH.name}` missing).\n\n"
+        )
+    elif not existing_cre_ids:
+        lines.append(
+            f"Prior baseline had no stored `cre_ids` (empty or unreadable `{OUTPUT_PATH.name}`).\n\n"
+        )
+    else:
+        lines.append(
+            f"Compared against `cre_ids` previously read from `{OUTPUT_PATH.as_posix()}`.\n\n"
+        )
+    lines.append(
+        "Counts are **per WSTG test id**; if the same id appeared more than once in JSON, "
+        "the last occurrence in the file defines the prior value.\n\n"
+    )
+    _delta_summary: list[tuple[str, int, str]] = [
+        ("Added", len(added), "No prior `cre_ids`, now non-empty"),
+        ("Removed", len(removed), "Had `cre_ids`, now absent or empty"),
+        ("Updated", len(updated), "Non-empty before and after, lists differ"),
+        ("Unchanged", unchanged_mapped, "Same non-empty `cre_ids` as prior"),
+        ("No mapping", unchanged_no_mapping, "No `cre_ids` before and after"),
+    ]
+    lines.append("| Status | Count | Disposition |\n")
+    lines.append("| --- | --: | --- |\n")
+    for label, count, disposition in _delta_summary:
+        emoji = _CRE_REPORT_EMOJI[label]
+        status_cell = f"{emoji} **{label}**"
+        disp = disposition.replace("|", "\\|")
+        lines.append(f"| {status_cell} | {count} | {disp} |\n")
+    lines.append("\n")
+
+    def pipe_escape(s: str) -> str:
+        return s.replace("|", "\\|")
+
+    if added:
+        lines.append(f"#### {_CRE_REPORT_EMOJI['Added']} Added ({len(added)})\n\n")
+        lines.append("| WSTG ID | CRE IDs |\n| --- | --- |\n")
+        for tid in _sort_test_ids_guide_order(added, guide_rank):
+            cell = pipe_escape(_format_cre_ids_cell(new_cre[tid]))
+            lines.append(f"| `{tid}` | {cell} |\n")
+        lines.append("\n")
+    if removed:
+        lines.append(f"#### {_CRE_REPORT_EMOJI['Removed']} Removed ({len(removed)})\n\n")
+        lines.append("| WSTG ID | Previous CRE IDs |\n| --- | --- |\n")
+        for tid in _sort_test_ids_guide_order(removed, guide_rank):
+            cell = pipe_escape(_format_cre_ids_cell(existing_cre_ids[tid]))
+            lines.append(f"| `{tid}` | {cell} |\n")
+        lines.append("\n")
+    if updated:
+        lines.append(f"#### {_CRE_REPORT_EMOJI['Updated']} Updated ({len(updated)})\n\n")
+        lines.append("| WSTG ID | Previous CRE IDs | New CRE IDs |\n| --- | --- | --- |\n")
+        for tid in _sort_test_ids_guide_order(updated, guide_rank):
+            prev_c = pipe_escape(_format_cre_ids_cell(existing_cre_ids[tid]))
+            new_c_cell = pipe_escape(_format_cre_ids_cell(new_cre[tid]))
+            lines.append(f"| `{tid}` | {prev_c} | {new_c_cell} |\n")
+        lines.append("\n")
+
+    lines.append("### `cre_ids` by test (guide order)\n\n")
+    rows = _cre_guide_status_table_rows(
+        data, existing_cre_ids, new_cre, guide_order_ids
+    )
+    lines.append(
+        f"**{len(rows)}** test id(s). **Status** compares prior `checklist.json` to this run: "
+        f"{_cre_status_display('Unchanged')} = same non-empty mapping; "
+        f"{_cre_status_display('No mapping')} = no `cre_ids` now (including still empty or cleared); "
+        f"{_cre_status_display('New')} / {_cre_status_display('Updated')} = mapping added or changed.\n\n"
+    )
+    lines.append("| WSTG ID | Name | Status | CRE IDs |\n")
     lines.append("| --- | --- | --- | --- |\n")
-    for category, tid, name, cre_cell in rows:
-        safe_cat = category.replace("|", "\\|")
-        safe_name = name.replace("|", "\\|")
-        safe_cre = cre_cell.replace("|", "\\|")
-        lines.append(f"| {safe_cat} | `{tid}` | {safe_name} | {safe_cre} |\n")
+    for tid, name, status_key, cre_cell in rows:
+        lines.append(
+            f"| `{tid}` | {pipe_escape(name)} | {_cre_status_display(status_key)} | "
+            f"{pipe_escape(cre_cell)} |\n"
+        )
     emit_markdown_report("".join(lines))
 
 
@@ -610,8 +780,10 @@ def build_checklist() -> OrderedDict:
 
 def main() -> None:
     data = build_checklist()
-    data = enrich_with_opencre(data)
-    _write_cre_mapping_success_report(data)
+    data, existing_cre_ids, unique_ids, opencre_failures = enrich_with_opencre(data)
+    _write_cre_opencre_summary_report(
+        data, existing_cre_ids, unique_ids, opencre_failures
+    )
     _write_empty_objectives_report(_empty_objective_entries(data))
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(data, indent=2, ensure_ascii=False) + "\n"


### PR DESCRIPTION
Improves generate_checklist_json.py reporting: shared emit_markdown_report (stdout + GITHUB_STEP_SUMMARY), one OpenCRE and cre_ids section with a delta table, guide-ordered per-test cre_ids table (status + emoji), and a one-line OpenCRE error summary (no per-ID failure table). OpenCRE failures use HTTP status on OpenCRELookupError; _cre_ids_map_from_categories and _CRE_REPORT_EMOJI reduce duplication. Test Objectives markdown copy is clearer.