### PR TITLE
Update outdated web spider tools (mark legacy + add modern alternatives)

### DIFF
--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.md
@@ -183,7 +183,7 @@ Vulnerability assessment tools tend to include checks to spot web directories ha
 ### Modern Alternatives
 
 - [Burp Suite](https://portswigger.net/burp) – widely used web security testing proxy
-- [OWASP ZAP](https://www.zaproxy.org/) – open-source web application security testing tool
+- [ZAP](https://www.zaproxy.org/) – open-source web application security testing tool
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) – website crawler and broken link checker
 
 Some of them are also included in standard Linux distributions. Web development tools usually include facilities to identify broken links and unreferenced files.

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information.md
@@ -173,11 +173,17 @@ Vulnerability assessment tools tend to include checks to spot web directories ha
 - [Nessus](https://www.tenable.com/products/nessus)
 - [Nikto2](https://cirt.net/Nikto2)
 
-Web spider tools
+### Web spider tools
 
 - [wget](https://www.gnu.org/software/wget/)
-- [Spike proxy includes a site crawler function](https://www.spikeproxy.com/)
-- [Xenu](https://home.snafu.de/tilman/xenulink.html)
+- Spike Proxy (legacy – no longer maintained; replaced by tools such as Burp Suite)
+- Xenu (legacy – last updated in 2010, no active maintenance)
 - [curl](https://curl.haxx.se)
+
+### Modern Alternatives
+
+- [Burp Suite](https://portswigger.net/burp) – widely used web security testing proxy
+- [OWASP ZAP](https://www.zaproxy.org/) – open-source web application security testing tool
+- [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) – website crawler and broken link checker
 
 Some of them are also included in standard Linux distributions. Web development tools usually include facilities to identify broken links and unreferenced files.


### PR DESCRIPTION
## Title

Update outdated web spider tools in WSTG-CONF-04 (mark legacy + add modern alternatives)

---

## Summary

This PR improves the "Web spider tools" section in WSTG-CONF-04 by marking outdated tools as legacy and introducing a small set of modern, widely used alternatives.

---

## Details

The following tools in the "Web spider tools" section are outdated or no longer actively maintained:

### Deprecated / Legacy Tools

* **Spike Proxy**

  * Status: Obsolete
  * No updates for many years
  * Replaced by modern web security testing proxies

* **Xenu (Xenu's Link Sleuth)**

  * Status: Unmaintained
  * Last release: 2010
  * No active development

---

### Still Valid Tools

* wget ✅
* curl ✅

---

## Proposed Changes

1. Mark outdated tools as "legacy" instead of removing them, to preserve historical context

2. Add a minimal set of modern alternatives:

* Burp Suite – widely used web security testing proxy
* ZAP – open-source web application security testing tool
* Screaming Frog SEO Spider – modern website crawler and link analysis tool

---

## Impact

* Improves clarity for modern users
* Prevents confusion caused by obsolete tools
* Keeps the guide aligned with current security practices

---

## Notes

This PR intentionally keeps changes minimal to align with the current structure while improving accuracy and usability.