### PR TITLE
Various small wording and typo fixes

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism.md
@@ -8,8 +8,9 @@
 
 Account lockout mechanisms are used to mitigate brute force attacks. Some of the attacks that can be defeated by using lockout mechanism:
 
-- Login password or username guessing attack.
-- Code guessing on any 2FA functionality or Security Questions.
+- Password guessing or brute-force attacks.
+- Security question guessing.
+- OTP code guessing for two-factor authentication (2FA/MFA).
 
 Account lockout mechanisms require a balance between protecting accounts from unauthorized access and protecting users from being denied authorized access. Accounts are typically locked after 3 to 5 unsuccessful attempts and can only be unlocked after a predetermined period of time, via a self-service unlock mechanism, or intervention by an administrator.
 
@@ -53,6 +54,7 @@ A CAPTCHA may hinder brute force attacks, but they can come with their own set o
 3. CAPTCHA server-side logic defaults to a successful solve.
 4. CAPTCHA challenge result is never validated server-side.
 5. CAPTCHA input field or parameter is manually processed, and is improperly validated or escaped.
+6. A single solved CAPTCHA can be re-used multiple times.
 
 To evaluate CAPTCHA effectiveness:
 
@@ -88,7 +90,7 @@ Factors to consider when implementing an account lockout mechanism:
 
 1. What is the risk of brute force password guessing against the application?
 2. Is a CAPTCHA sufficient to mitigate this risk?
-3. Is a client-side lockout mechanism being used (e.g., JavaScript)? (If so, disable the client-side code to test.)
+3. Is a client-side lockout mechanism being used (e.g., JavaScript)? (if so, disable the client-side code to test.)
 4. Number of unsuccessful log in attempts before lockout. If the lockout threshold is too low then valid users may be locked out too often. If the lockout threshold is too high then the more attempts an attacker can make to brute force the account before it will be locked. Depending on the application's purpose, a range of 5 to 10 unsuccessful attempts is a typical lockout threshold.
 5. How will accounts be unlocked?
     1. Manually by an administrator: this is the most secure lockout method, but may cause inconvenience to users and take up the administrator's "valuable" time.

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/05.1-Testing_for_OAuth_Authorization_Server_Weaknesses.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/05.1-Testing_for_OAuth_Authorization_Server_Weaknesses.md
@@ -15,7 +15,7 @@ Failure to validate the parameters may lead to account takeover, unauthorized re
 In order to test for AS weaknesses, you will aim to:
 
 1. Retrieve credentials used for authorization.
-2. Grant yourself access to arbitrary resources through forceful browsing.
+2. Grant yourself access to arbitrary resources through forced browsing.
 3. Bypass the authorization.
 
 ### Testing for Insufficient Redirect URI Validation

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/05.2-Testing_for_OAuth_Client_Weaknesses.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/05.2-Testing_for_OAuth_Client_Weaknesses.md
@@ -15,7 +15,7 @@ Failure to protect the token exchange and credentials may result in unauthorized
 In order to test for client weaknesses, you will aim to:
 
 1. Retrieve credentials used for authorization.
-2. Grant yourself access to arbitrary resources through forceful browsing.
+2. Grant yourself access to arbitrary resources through forced browsing.
 3. Bypass the authorization.
 
 ### Testing for Exposed Client Secret

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
@@ -202,7 +202,6 @@ If source code is available (white-box testing), all variables received from use
 
 ## Tools
 
-
 - [Hackvertor](https://hackvertor.co.uk/) is an online tool which allows many types of encoding and obfuscation of JavaScript (or any string input).
 - [XSS-Proxy](https://xss-proxy.sourceforge.net/) is an advanced Cross-Site-Scripting (XSS) attack tool.
 - [ratproxy](https://code.google.com/archive/p/ratproxy/) is a semi-automated, largely passive web application security audit tool, optimized for an accurate and sensitive detection, and automatic annotation, of potential problems and security-relevant design patterns based on the observation of existing, user-initiated traffic in complex web 2.0 environments.

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
@@ -6,13 +6,13 @@
 
 ## Summary
 
-Reflected [Cross-site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) occur when an attacker injects browser executable code within a single HTTP response. The injected attack is not stored within the application itself; it is non-persistent and only impacts users who open a maliciously crafted link or third-party web page. The attack string is included as part of the crafted URI or HTTP parameters, improperly processed by the application, and returned to the victim.
+Reflected [Cross-site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) occurs when an attacker injects browser executable code within a single HTTP response. The injected attack is not stored within the application itself; it is non-persistent and only impacts users who open a maliciously crafted link or third-party web page. The attack string is included as part of the crafted URI or HTTP parameters, improperly processed by the application, and returned to the victim.
 
 Reflected XSS are the most frequent type of XSS attacks found in the wild. Reflected XSS attacks are also known as non-persistent XSS attacks and, since the attack payload is delivered and executed via a single request and response, they are also referred to as first-order or type 1 XSS.
 
 When a web application is vulnerable to this type of attack, it will pass unvalidated input sent through requests back to the client. The common modus operandi of the attack includes a design step, in which the attacker creates and tests an offending URI, a social engineering step, in which she convinces her victims to load this URI on their browsers, and the eventual execution of the offending code using the victim's browser.
 
-Commonly the attacker's code is written in the JavaScript language, but other scripting languages are also used, e.g., ActionScript and VBScript. Attackers typically leverage these vulnerabilities to install key loggers, steal victim cookies, perform clipboard theft, and change the content of the page (e.g., download links).
+Commonly the attacker's code is written in the JavaScript language, but other scripting languages such as ActionScript and VBScript can also be used. Attackers typically leverage these vulnerabilities to install key loggers, steal victim cookies, perform clipboard theft, and change the content of the page (e.g., download links).
 
 One of the primary difficulties in preventing XSS vulnerabilities is proper character encoding. In some cases, the web server or the web application could not be filtering some encodings of characters, so, for example, the web application might filter out `<script>`, but might not filter `%3cscript%3e` which simply includes another encoding of tags.
 
@@ -86,7 +86,7 @@ If no sanitization is applied this will result in the following popup:
 ![Alert](images/Alert.png)\
 *Figure 4.7.1-2: XSS Example 1*
 
-This indicates that there is an XSS vulnerability and it appears that the tester can execute code of his choice in anybody's browser if he clicks on the tester's link.
+This indicates that there is an XSS vulnerability and it appears that the tester can execute code of his choice in anybody's browser if the target clicks on the tester's link.
 
 #### Example 2
 
@@ -196,7 +196,7 @@ See the [XSS Filter Evasion Cheat Sheet](https://owasp.org/www-community/xss-fil
 
 ### Gray-Box Testing
 
-Gray-box testing is similar to black-box testing. In gray-box testing, the pen-tester has partial knowledge of the application. In this case, information regarding user input, input validation controls, and how the user input is rendered back to the user might be known by the pen-tester.
+Gray-box testing is similar to black-box testing. In gray-box testing, the pentester has partial knowledge of the application. In this case, information regarding user input, input validation controls, and how the user input is rendered back to the user might be known by the pentester.
 
 If source code is available (white-box testing), all variables received from users should be analyzed. Moreover the tester should analyze any sanitization procedures implemented to decide if these can be circumvented.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting.md
@@ -202,8 +202,8 @@ If source code is available (white-box testing), all variables received from use
 
 ## Tools
 
-- [PHP Charset Encoder(PCE)](https://cybersecurity.wtf/encoder/) helps you encode arbitrary texts to and from 65 kinds of character sets that you can use in your customized payloads.
-- [Hackvertor](https://hackvertor.co.uk/public) is an online tool which allows many types of encoding and obfuscation of JavaScript (or any string input).
+
+- [Hackvertor](https://hackvertor.co.uk/) is an online tool which allows many types of encoding and obfuscation of JavaScript (or any string input).
 - [XSS-Proxy](https://xss-proxy.sourceforge.net/) is an advanced Cross-Site-Scripting (XSS) attack tool.
 - [ratproxy](https://code.google.com/archive/p/ratproxy/) is a semi-automated, largely passive web application security audit tool, optimized for an accurate and sensitive detection, and automatic annotation, of potential problems and security-relevant design patterns based on the observation of existing, user-initiated traffic in complex web 2.0 environments.
 - [Burp Proxy](https://portswigger.net/burp/) is an interactive HTTP/S proxy server for attacking and testing web applications.
@@ -225,4 +225,4 @@ If source code is available (white-box testing), all variables received from use
 
 - [CERT - Malicious HTML Tags Embedded in Client Web Requests](https://resources.sei.cmu.edu/asset_files/WhitePaper/2000_019_001_496188.pdf)
 - [cgisecurity.com - The Cross Site Scripting FAQ](https://www.cgisecurity.com/xss-faq.html)
-- [S. Frei, T. Dübendorfer, G. Ollmann, M. May - Understanding the Web browser threat](https://www.techzoom.net/Publications/Insecurity-Iceberg)
+- [S. Frei, T. Dübendorfer, G. Ollmann, M. May - Understanding the Web browser threat](https://www.researchgate.net/publication/230751208_Understanding_the_Web_browser_threat_Examination_of_vulnerable_online_Web_browser_populations_and_the_insecurity_iceberg)

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
@@ -53,13 +53,13 @@ The first step is to identify all points where user input is stored into the bac
 - Blog: if the blog application permits to users submitting comments
 - Log: if the application stores some users input into logs.
 
-Note that this can also include URL paths, cookies, HTTP headers and other less-obvious types of user input, as well as GET and POST parameters.
+> Note: This can also include URL paths, cookies, HTTP headers and other less-obvious types of user input, as well as GET and POST parameters.
 
 #### Analyze HTML Code
 
 Input stored by the application is normally used in HTML tags, but it can also be found as part of JavaScript content. At this stage, it is fundamental to understand if input is stored and how it is positioned in the context of the page. Differently from reflected XSS, the pentester should also investigate any out-of-band channels through which the application receives and stores users input, such as via email or integration with external applications.
 
-**Note**: All areas of the application accessible by administrators should be tested to identify the presence of any data submitted by users.
+> Note: All areas of the application accessible by administrators should be tested to identify the presence of any data submitted by users.
 
 **Example**: Email stored data in `index2.php`
 
@@ -181,7 +181,7 @@ The following table summarizes some special variables and functions to look at w
 | `$_FILES` - HTTP File Upload variables | | |
 | `$_SERVER` - HTTP headers | | |
 
-**Note**: The table above is only a summary of the most important parameters but, all user input parameters should be investigated.
+> Note: The table above is only a summary of the most important parameters but, all user input parameters should be investigated.
 
 ## Tools
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
@@ -19,12 +19,12 @@ This vulnerability can be used to conduct a number of browser-based attacks incl
 - Directed delivery of browser-based exploits
 - Other malicious activities
 
-Stored XSS does not need a malicious link to be exploited. A successful exploitation occurs when a user visits a page with a stored XSS. The following phases relate to a typical stored XSS attack scenario:
+Stored XSS does not need the victim to click a malicious link - exploitation occurs when a user visits a page with a stored XSS. The following phases relate to a typical stored XSS attack scenario:
 
-- Attacker stores malicious code into the vulnerable page
-- User authenticates in the application
-- User visits vulnerable page
-- Malicious code is executed by the user's browser
+- The attacker stores malicious code into the vulnerable page
+- The victim authenticates in the application
+- The victim views the vulnerable page
+- Malicious code is executed by the victim's browser
 
 This type of attack can also be exploited with browser exploitation frameworks such as [BeEF](https://beefproject.com) and [XSS Proxy](https://xss-proxy.sourceforge.net/). These frameworks allow for complex JavaScript exploit development.
 
@@ -53,9 +53,11 @@ The first step is to identify all points where user input is stored into the bac
 - Blog: if the blog application permits to users submitting comments
 - Log: if the application stores some users input into logs.
 
+Note that this can also include URL paths, cookies, HTTP headers and other less-obvious types of user input, as well as GET and POST parameters.
+
 #### Analyze HTML Code
 
-Input stored by the application is normally used in HTML tags, but it can also be found as part of JavaScript content. At this stage, it is fundamental to understand if input is stored and how it is positioned in the context of the page. Differently from reflected XSS, the pen-tester should also investigate any out-of-band channels through which the application receives and stores users input.
+Input stored by the application is normally used in HTML tags, but it can also be found as part of JavaScript content. At this stage, it is fundamental to understand if input is stored and how it is positioned in the context of the page. Differently from reflected XSS, the pentester should also investigate any out-of-band channels through which the application receives and stores users input, such as via email or integration with external applications.
 
 **Note**: All areas of the application accessible by administrators should be tested to identify the presence of any data submitted by users.
 
@@ -123,7 +125,7 @@ When the user loads the page `index2.php`, the script `hook.js` is executed by t
 
 #### File Upload
 
-If the web application allows file upload, it is important to check if it is possible to upload HTML content. For instance, if HTML or TXT files are allowed, XSS payload can be injected in the file uploaded. The pen-tester should also verify if the file upload allows setting arbitrary MIME types.
+If the web application allows file upload, it is important to check if it is possible to upload HTML content. For instance, if HTML or TXT files are allowed, XSS payload can be injected in the uploaded file. The pentester should also verify if the file upload allows setting arbitrary MIME types.
 
 Consider the following HTTP POST request for file upload:
 
@@ -153,11 +155,11 @@ Also consider that Internet Explorer does not handle MIME types in the same way 
 
 Blind Cross-site Scripting is a form of stored XSS. It generally occurs when the attacker’s payload is saved on the server/infrastructure and later reflected back to the victim from the backend application. For example in feedback forms, an attacker can submit the malicious payload using the form, and once the backend user/admin of the application views the attacker’s submission via the backend application, the attacker’s payload will get executed. Blind Cross-site Scripting is hard to confirm in the real-world scenario but one of the best tools for this is [XSS Hunter](https://xsshunter.com/).
 
-> Note: Testers should carefully consider the privacy implications of using public or third party services while performing security tests. (See #tools.)
+> Note: Testers should carefully consider the privacy implications of using public or third party services while performing security tests. (See [#tools](#tools).)
 
 ### Gray-Box Testing
 
-Gray-box testing is similar to black-box testing. In gray-box testing, the pen-tester has partial knowledge of the application. In this case, information regarding user input, input validation controls, and data storage might be known by the pen-tester.
+Gray-box testing is similar to black-box testing. In gray-box testing, the pentester has partial knowledge of the application. In this case, information regarding user input, input validation controls, and data storage might be known by the pentester.
 
 Depending on the information available, it is normally recommended that testers check how user input is processed by the application and then stored into the backend system. The following steps are recommended:
 
@@ -177,6 +179,7 @@ The following table summarizes some special variables and functions to look at w
 | `$_POST` - HTTP POST variables| `Request.Form` - HTTP POST | `request.getParameter` - HTTP GET/POST variables |
 | `$_REQUEST` – HTTP POST, GET and COOKIE variables | `Server.CreateObject` - used to upload files | |
 | `$_FILES` - HTTP File Upload variables | | |
+| `$_SERVER` - HTTP headers | | |
 
 **Note**: The table above is only a summary of the most important parameters but, all user input parameters should be investigated.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting.md
@@ -96,7 +96,7 @@ Ensure the input is submitted through the application. This normally involves di
 > <input class="inputbox" type="text" name="email" size="40" value="aaa@aa.com"><script>alert(document.cookie)</script>
 > ```
 >
-> The input is stored and the XSS payload is executed by the browser when reloading the page. If the input is escaped by the application, testers should test the application for XSS filters. For instance, if the string "SCRIPT" is replaced by a space or by a NULL character then this could be a potential sign of XSS filtering in action. Many techniques exist in order to evade input filters (see [testing for reflected XSS](01-Testing_for_Reflected_Cross_Site_Scripting.md)) chapter). It is strongly recommended that testers refer to [XSS Filter Evasion](https://owasp.org/www-community/xss-filter-evasion-cheatsheet) and [Mario](https://cybersecurity.wtf/encoder/) XSS Cheat pages, which provide an extensive list of XSS attacks and filtering bypasses. Refer to the whitepapers and tools section for more detailed information.
+> The input is stored and the XSS payload is executed by the browser when reloading the page. If the input is escaped by the application, testers should test the application for XSS filters. For instance, if the string "SCRIPT" is replaced by a space or by a NULL character then this could be a potential sign of XSS filtering in action. Many techniques exist in order to evade input filters (see [testing for reflected XSS](01-Testing_for_Reflected_Cross_Site_Scripting.md)) chapter). It is strongly recommended that testers refer to [XSS Filter Evasion](https://owasp.org/www-community/xss-filter-evasion-cheatsheet) and other XSS Cheat pages, which provide an extensive list of XSS attacks and filtering bypasses. Refer to the whitepapers and tools section for more detailed information.
 
 #### Leverage Stored XSS with BeEF
 
@@ -185,7 +185,6 @@ The following table summarizes some special variables and functions to look at w
 
 ## Tools
 
-- [PHP Charset Encoder(PCE)](https://cybersecurity.wtf/encoder/) helps you encode arbitrary texts to and from 65 kinds of character sets that you can use in your customized payloads.
 - [Hackvertor](https://hackvertor.co.uk/public) is an online tool which allows many types of encoding and obfuscation of JavaScript (or any string input).
 - [BeEF](https://www.beefproject.com) is the browser exploitation framework. A professional tool to demonstrate the real-time impact of browser vulnerabilities.
 - [XSS-Proxy](https://xss-proxy.sourceforge.net/) is an advanced Cross-Site-Scripting (XSS) attack tool.

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.md
@@ -69,7 +69,9 @@ Given the URL and querystring: `https://example.com/?color=red&color=blue`
 
 ## How to Test
 
-Luckily, because the assignment of HTTP parameters is typically handled via the web application server, and not the application code itself, testing the response to parameter pollution should be standard across all pages and actions. However, as in-depth business logic knowledge is necessary, testing HPP requires manual testing. Automatic tools can only partially assist auditors as they tend to generate too many false positives. In addition, HPP can manifest itself in client-side and server-side components.
+Whether an specific page or API endpoint is vulnerable to HPP will depend on the interaction between multiple components, including the application, the web server, the web application firewall and any middleware. Where these vary for different parts of an application (such as a microservice architecture), this can result in some parts of the application being vulnerable and not others.
+
+As in-depth business logic knowledge is necessary, testing HPP requires manual testing. Automatic tools can only partially assist auditors as they tend to generate too many false positives. In addition, HPP can manifest itself in client-side and server-side components.
 
 ### Server-Side HPP
 
@@ -110,7 +112,7 @@ and submit the new request.
 
 Analyze the response page to determine which value(s) were parsed. In the above example, the search results may show `kittens`, `puppies`, some combination of both (`kittens,puppies` or `kittens~puppies` or `['kittens','puppies']`), may give an empty result, or error page.
 
-This behavior, whether using the first, last, or combination of input parameters with the same name, is very likely to be consistent across the entire application. Whether or not this default behavior reveals a potential vulnerability depends on the specific input validation and filtering specific to a particular application. As a general rule: if existing input validation and other security mechanisms are sufficient on single inputs, and if the server assigns only the first or last polluted parameters, then parameter pollution does not reveal a vulnerability. If the duplicate parameters are concatenated, different web application components use different occurrences or testing generates an error, there is an increased likelihood of being able to use parameter pollution to trigger security vulnerabilities.
+Whether or not this default behavior reveals a potential vulnerability depends on the specific input validation and filtering specific to a particular application. As a general rule: if existing input validation and other security mechanisms are sufficient on single inputs, and if the server assigns only the first or last polluted parameters, then parameter pollution does not reveal a vulnerability. If the duplicate parameters are concatenated, different web application components use different occurrences or testing generates an error, there is an increased likelihood of being able to use parameter pollution to trigger security vulnerabilities.
 
 A more in-depth analysis would require three HTTP requests for each HTTP parameter:
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -489,7 +489,7 @@ Automation:
 
 #### Boolean Exploitation Technique
 
-The Boolean exploitation technique is very useful when the tester finds a [Blind SQL Injection](https://owasp.org/www-community/attacks/Blind_SQL_Injection) situation, in which nothing is known about the outcome of an operation. For example, this behavior happens in cases where the programmer has created a custom error page that does not reveal anything about the structure of the query or the database. (The page does not return a SQL error, it may just return an HTTP 500, 404, or redirect).
+The Boolean exploitation technique is very useful when the tester finds a [Blind SQL Injection](https://owasp.org/www-community/attacks/Blind_SQL_Injection) situation, in which nothing is known about the outcome of an operation. For example, this behavior happens in cases where the programmer has created a custom error page that does not reveal anything about the structure of the query or the database, or return any SQL error - it may just return a HTTP 404 or 500, or a browser redirect.
 
 By using inference methods, it is possible to avoid this obstacle and thus succeed in recovering the values of some desired fields. This method consists of carrying out a series of boolean queries against the server, observing the answers, and finally deducing the meaning of such answers. We consider, as always, the `www.example.com` domain and we suppose that it contains a parameter named `id` vulnerable to SQL injection. This means that when carrying out the following request:
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL.md
@@ -4,7 +4,7 @@
 
 [SQL Injection](https://owasp.org/www-community/attacks/SQL_Injection) vulnerabilities occur whenever input is used in the construction of a SQL query without being adequately constrained or sanitized. The use of dynamic SQL (the construction of SQL queries by concatenation of strings) opens the door to these vulnerabilities. SQL injection allows an attacker to access the SQL servers. It allows for the execution of SQL code under the privileges of the user used to connect to the database.
 
-*MySQL server* has a few particularities so that some exploits need to be specially customized for this application. That's the subject of this section.
+*MySQL server* has a few particularities so that some exploits need to be specially customized for this application. That's the subject of this section. Note that as MariaDB is a fork of MySQL, teh contents of this page will also be relevant for MariaDB.
 
 ## How to Test
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
@@ -41,7 +41,7 @@ Alternatively, we can use `sp_makewebtask`:
 
 `exec sp_makewebtask 'C:\Inetpub\wwwroot\test.txt', 'select * from master.dbo.sysobjects'--`
 
-A successful execution will create a file that can be browsed by the pen tester. Keep in mind that `sp_makewebtask` is deprecated, and, even if it works in all SQL Server versions up to 2005, it might be removed in the future.
+A successful execution will create a file that can be browsed by the pentester. Keep in mind that `sp_makewebtask` is deprecated, and, even if it works in all SQL Server versions up to 2005, it might be removed in the future.
 
 In addition, SQL Server built-in functions and environment variables are very handy. The following uses the function `db_name()` to trigger an error that will return the name of the database:
 
@@ -159,7 +159,7 @@ Allows the execution of arbitrary SQL Code. The same happens with the User-Agent
 
 ### Example 7: SQL Server as a Port Scanner
 
-In SQL Server, one of the most useful (at least for the penetration tester) commands is OPENROWSET, which is used to run a query on another DB Server and retrieve the results. The penetration tester can use this command to scan ports of other machines in the target network, injecting the following query:
+In SQL Server, one of the most useful (at least for the pentester) commands is OPENROWSET, which is used to run a query on another DB Server and retrieve the results. The penetration tester can use this command to scan ports of other machines in the target network, injecting the following query:
 
 `select * from OPENROWSET('SQLOLEDB','uid=sa;pwd=foobar;Network=DBMSSOCN;Address=x.y.w.z,p;timeout=5','select 1')--`
 
@@ -207,7 +207,7 @@ At this point, our executable is available on the target machine, ready to be ex
 
 ### Obtain Information When It Is Not Displayed (Out of Band)
 
-Not all is lost when the web application does not return any information --such as descriptive error messages (cf. [Blind SQL Injection](https://owasp.org/www-community/attacks/Blind_SQL_Injection)). For example, it might happen that one has access to the source code (e.g., because the web application is based on an open source software). Then, the pen tester can exploit all the SQL injection vulnerabilities discovered offline in the web application. Although an IPS might stop some of these attacks, the best way would be to proceed as follows: develop and test the attacks in a testbed created for that purpose, and then execute these attacks against the web application being tested.
+Not all is lost when the web application does not return any information --such as descriptive error messages (cf. [Blind SQL Injection](https://owasp.org/www-community/attacks/Blind_SQL_Injection)). For example, it might happen that one has access to the source code (e.g., because the web application is based on an open source software). Then, the pentester can exploit all the SQL injection vulnerabilities discovered offline in the web application. Although an IPS might stop some of these attacks, the best way would be to proceed as follows: develop and test the attacks in a testbed created for that purpose, and then execute these attacks against the web application being tested.
 
 Other options for out of band attacks are described in [Sample 4 above](#example-4-yet-another-useful-get-example).
 
@@ -240,7 +240,7 @@ There is one more possibility for making a blind SQL injection attack when there
 
 `if exists (select * from pubs..pub_info) waitfor delay '0:0:5'`
 
-Depending on the time that the query takes to return, we will know the answer. In fact, what we have here is two things: a `SQL injection vulnerability` and a `covert channel` that allows the penetration tester to get 1 bit of information for each query. Hence, using several queries (as many queries as bits in the required information) the pen tester can get any data that is in the database. Look at the following query
+Depending on the time that the query takes to return, we will know the answer. In fact, what we have here is two things: a `SQL injection vulnerability` and a `covert channel` that allows the penetration tester to get 1 bit of information for each query. Hence, using several queries (as many queries as bits in the required information) the pentester can get any data that is in the database. Look at the following query
 
 ```sql
 declare @s varchar(8000)
@@ -256,7 +256,7 @@ Measuring the response time and using different values for `@i`, we can deduce t
 
 This query will wait for 5 seconds if bit `@bit` of byte `@byte` of the name of the current database is 1, and will return at once if it is 0. Nesting two cycles (one for `@byte` and one for `@bit`) we will we able to extract the whole piece of information.
 
-However, it might happen that the command `waitfor` is not available (e.g., because it is filtered by an IPS/web application firewall). This doesn't mean that blind SQL injection attacks cannot be done, as the pen tester should only come up with any time consuming operation that is not filtered. For example
+However, it might happen that the command `waitfor` is not available (e.g., because it is filtered by an IPS/web application firewall). This doesn't mean that blind SQL injection attacks cannot be done, as the pentester should only come up with any time consuming operation that is not filtered. For example
 
 ```sql
 declare @i int select @i = 0

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
@@ -48,7 +48,7 @@ Even if the input used within queries is completely sanitized or parameterized, 
 
 For example within MongoDB, the `$where` syntax itself is a reserved query operator. It needs to be passed into the query exactly as shown; any alteration would cause a database error. However, because `$where` is also a valid PHP variable name, it may be possible for an attacker to insert code into the query by creating a PHP variable named `$where`. The PHP MongoDB documentation explicitly warns developers:
 
-Please make sure that for all special query operators (starting with `$`) you use single quotes so that PHP doesn't try to replace `$exists` with the value of the variable `$exists`.
+> Please make sure that for all special query operators (starting with `$`) you use single quotes so that PHP doesn't try to replace `$exists` with the value of the variable `$exists`.
 
 Even if a query depended on no user input, such as the following example, an attacker could exploit MongoDB by replacing the operator with malicious data.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.md
@@ -6,9 +6,9 @@
 
 ## Summary
 
-XML Injection testing is when a tester tries to inject an XML doc to the application. If the XML parser fails to contextually validate data, then the test will yield a positive result.
+XML Injection testing is when a tester tries to inject an XML document into the application. If the XML parser fails to contextually validate data, then the test will yield a positive result.
 
-This section describes practical examples of XML Injection. First, an XML style communication will be defined and its working principles explained. Then, the discovery method in which we try to insert XML metacharacters. Once the first step is accomplished, the tester will have some information about the XML structure, so it will be possible to try to inject XML data and tags (Tag Injection).
+This section describes practical examples of XML Injection. First, an XML style communication will be defined and its working principles explained. Then, the discovery method in which we try to insert XML metacharacters. Once the first step is accomplished, the tester will have some information about the XML structure, so it will be possible to try to inject XML data and tags (tag injection).
 
 ## Test Objectives
 
@@ -17,7 +17,7 @@ This section describes practical examples of XML Injection. First, an XML style 
 
 ## How to Test
 
-Let's suppose there is a web application using an XML style communication in order to perform user registration. This is done by creating and adding a new `user>`node in an `xmlDb` file.
+Let's suppose there is a web application using an XML style communication in order to perform user registration. This is done by creating and adding a new `<user>`node in an `xmlDb` file.
 
 Let's suppose the xmlDB file is like the following:
 
@@ -143,7 +143,7 @@ the application will build a new node:
 
 but, because of the presence of the open '<', the resulting XML document is invalid.
 
-- Comment tag: `<!--/-->` - This sequence of characters is interpreted as the beginning/end of a comment. So by injecting one of them in Username parameter:
+- Comment tag: `<!--` and `-->` - This sequence of characters is interpreted as the beginning or end of a comment. So by injecting one of them in Username parameter:
 
 `Username = foo<!--`
 
@@ -187,7 +187,7 @@ a new node will be created:
 
 but, again, the document is not valid: `&foo` is not terminated with `;` and the `&foo;` entity is undefined.
 
-- CDATA section delimiters: `<!\[CDATA\[ / ]]>` - CDATA sections are used to escape blocks of text containing characters which would otherwise be recognized as markup. In other words, characters enclosed in a CDATA section are not parsed by an XML parser.
+- CDATA section delimiters: `<![CDATA[` and `]]>` - CDATA sections are used to escape blocks of text containing characters which would otherwise be recognized as markup. In other words, characters enclosed in a CDATA section are not parsed by an XML parser.
 
 For example, if there is the need to represent the string `<foo>` inside a text node, a CDATA section may be used:
 
@@ -318,7 +318,7 @@ the application will build a new node and append it to the XML database:
 </users>
 ```
 
-The resulting XML file is well formed. Furthermore, it is likely that, for the user tony, the value associated with the userid tag is the one appearing last, i.e., 0 (the admin ID). In other words, we have injected a user with administrative privileges.
+The resulting XML file is well formed. Furthermore, it is likely that, for the user "tony", the value associated with the userid tag is the one appearing last, i.e., 0 (the admin ID). In other words, we have injected a user with administrative privileges.
 
 The only problem is that the userid tag appears twice in the last user node. Often, XML documents are associated with a schema or a DTD and will be rejected if they don't comply with it.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Web servers usually give developers the ability to add small pieces of dynamic code inside static HTML pages, without having to deal with full-fledged server-side or client-side languages. This feature is provided by [Server-Side Includes](https://owasp.org/www-community/attacks/Server-Side_Includes_%28SSI%29_Injection)(SSI).
+Web servers usually give developers the ability to add small pieces of dynamic code inside static HTML pages, without having to deal with full-fledged server-side or client-side languages. This feature is provided by [Server-Side Includes](https://owasp.org/www-community/attacks/Server-Side_Includes_%28SSI%29_Injection) (SSI).
 
 Server-Side Includes are directives that the web server parses before serving the page to the user. They represent an alternative to writing CGI programs or embedding code using server-side scripting languages, when there's only need to perform very simple tasks. Common SSI implementations provide directives (commands) to include external files, to set and print web server CGI environment variables, or to execute external CGI scripts or system commands.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection.md
@@ -52,7 +52,7 @@ Username: ' or '1' = '1
 Password: ' or '1' = '1
 ```
 
-Looks quite familiar, doesn't it? Using these parameters, the query becomes:
+Using these parameters, the query becomes:
 
 `string(//user[username/text()='' or '1' = '1' and password/text()='' or '1' = '1']/account/text())`
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
@@ -78,9 +78,10 @@ The following examples can be used.
 `https://<webmail>/src/read_body.php?passed_id=46106&startMessage=1`
 
 The final result of the above testing gives the tester three possible situations:
-S1 - The application returns a error code/message
-S2 - The application does not return an error code/message, but it does not realize the requested operation
-S3 - The application does not return an error code/message and realizes the operation requested normally
+
+1. The application returns a error code/message
+2. The application does not return an error code/message, but it does not realize the requested operation
+3. The application does not return an error code/message and realizes the operation requested normally
 
 Situations S1 and S2 represent successful IMAP/SMTP injection.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability.md
@@ -67,9 +67,9 @@ Now, each user browsing the site will silently send their cookies to the `attack
 
 #### Misconfigured Server
 
-Some web servers present an administration interface that may allow an attacker to upload active components of her choice to the site. This could be the case with an Apache Tomcat server that doesn’t enforce strong credentials to access its Web Application Manager (or if the pen testers have been able to obtain valid credentials for the administration module by other means).
+Some web servers present an administration interface that may allow an attacker to upload active components of her choice to the site. This could be the case with an Apache Tomcat server that doesn’t enforce strong credentials to access its Web Application Manager (or if the pentesters have been able to obtain valid credentials for the administration module by other means).
 
-In this case, a WAR file can be uploaded and a new web application deployed at the site, which will not only allow the pen tester to execute code of her choice locally at the server, but also to plant an application at the trusted site, which the site regular users can then access (most probably with a higher degree of trust than when accessing a different site).
+In this case, a WAR file can be uploaded and a new web application deployed at the site, which will not only allow the pentester to execute code of her choice locally at the server, but also to plant an application at the trusted site, which the site regular users can then access (most probably with a higher degree of trust than when accessing a different site).
 
 As should also be obvious, the ability to change web page contents at the server, via any vulnerabilities that may be exploitable at the host which will give the attacker webroot write permissions, will also be useful towards planting such an incubated attack on the web server pages (actually, this is a known infection-spread method for some web server worms).
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery.md
@@ -79,8 +79,9 @@ Some applications block references to `localhost` and `127.0.0.1`. This can be c
     - Decimal notation: `2130706433`
     - Octal notation: `017700000001`
     - IP shortening: `127.1`
+    - Alternative IPs treated as loopback: `127.0.0.2`
 - String obfuscation
-- Registering your own domain that resolves to `127.0.0.1`
+- Creating a public DNS on a domain you own that resolves to `127.0.0.1`
 
 Sometimes the application allows input that matches a certain expression, like a domain. That can be circumvented if the URL schema parser is not properly implemented, resulting in attacks similar to [semantic attacks](https://tools.ietf.org/html/rfc3986#section-7.6).
 

--- a/document/4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets.md
+++ b/document/4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets.md
@@ -63,7 +63,7 @@ Using a WebSocket client (one can be found in the Tools section below) attempt t
 
 ### Gray-Box Testing
 
-Gray-box testing is similar to black-box testing. In gray-box testing, the pen-tester has partial knowledge of the application. The only difference here is that you may have API documentation for the application being tested which includes the expected WebSocket request and responses.
+Gray-box testing is similar to black-box testing. In gray-box testing, the pentester has partial knowledge of the application. The only difference here is that you may have API documentation for the application being tested which includes the expected WebSocket request and responses.
 
 ## Tools
 


### PR DESCRIPTION
Various small wording and grammar fixes.

The only real change is to remove a comment from the HTTP parameter pollution page saying that the results are likely to be the same on every page of a site - in the days of microservices this is no longer true.