### PR TITLE
Fix typo in Testing for Default Credentials section

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -59,7 +59,7 @@ The passwords may be based on:
 - A time-based algorithm.
 - A weak pseudo-random number generator (PRNG).
 
-This type of issue of often difficult to identify from a black-box perspective.
+This type of issue is often difficult to identify from a black-box perspective.
 
 ## Tools
 


### PR DESCRIPTION
Incorrectly had:
of
Instead of
is

Correcting typo originally submitted against the wrong repo in #564

Also identified typo in the warning message displayed after making a pr: Have you followed the "contributions guideance"
Last word should be
guidance

<img width="739" height="103" alt="Screenshot 2026-07-30 111931" src="https://github.com/user-attachments/assets/6b7b4a80-36e3-4848-a3b0-818db4a3d5b6" />
