### PR TITLE
feat(www): add sidebar filter aliases and IDs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -100,14 +100,23 @@ This workflow:
 
 ## `www_latest_update.yml`
 
-Publishes the latest web content using the @wstgbot account to `OWASP/www-project-web-security-testing-guide`.
+Publishes the latest web content using the @wstgbot account to
+`OWASP/www-project-web-security-testing-guide`.
 
-- Trigger: Push.
-- See: `/.github/www/latest/` in the root of the repository.
+- Trigger: Push to `master` when `document/**` changes, or manual (`workflow_dispatch`).
+- Copies `document/` into the www repo’s `latest/`, prepends front matter, copies `info.md`.
+- Runs `.github/www/scripts/generate_nav.py` to write:
+  - `_data/latest.yaml` (nested ToC + filter hints)
+  - `_includes/nav-tree-latest.html` (pre-rendered sidebar tree)
+  - Slim chapter-only `latest/README.md` / `index.md` landing ToC
+- See: `/.github/www/latest/` and `/.github/www/scripts/README.md`.
 
 ## `www_stable_update.yml`
 
-Publishes stable and versioned web content using the @wstgbot account to `OWASP/www-project-web-security-testing-guide`.
+Publishes stable and versioned web content using the @wstgbot account to
+`OWASP/www-project-web-security-testing-guide`.
 
 - Trigger: Tag applied to repository (format `v*`).
-- See: `/.github/www/` in the root of the repository.
+- Same nav generation as latest, for `stable` and the version folder (e.g. `v42`),
+  including `nav-tree-<collection>.html` and nested `_data/*.yaml`.
+- See: `/.github/www/` and `/.github/www/scripts/README.md`.

--- a/.github/workflows/scripts/README.md
+++ b/.github/workflows/scripts/README.md
@@ -2,6 +2,9 @@
 
 This directory contains helper scripts used by GitHub Actions workflows.
 
+For website publish / sidebar nav generation, see
+[`../../www/scripts/README.md`](../../www/scripts/README.md) (`generate_nav.py`).
+
 ## Scripts
 
 ### format_lint_output.py

--- a/.github/www/README.md
+++ b/.github/www/README.md
@@ -1,11 +1,24 @@
 # www
 
-This directory contains github action dependencies for deployment of content to the owasp.org project website.
+This directory contains GitHub Action dependencies for deploying WSTG content to
+the OWASP project website
+([www-project-web-security-testing-guide](https://github.com/OWASP/www-project-web-security-testing-guide)).
 
-- latest
-- stable
-- v41, etc.
+Per-channel templates:
 
-## assets
+- `latest/`
+- `stable/`
+- `v41/`, `v42/`, `v43/`, etc.
 
-This folder is a storage location for the project's social/graphic assets.
+Each channel typically has `prepend.txt` (front matter + asset tags), `prepend.nav`
+(sidebar title), and `info.md` (includes the shared navigation partial).
+
+## scripts/
+
+Publish helpers. See [`scripts/README.md`](scripts/README.md).
+
+- `generate_nav.py` — nested sidebar YAML/HTML + filter hints from `document/README.md`
+
+## assets/
+
+Project social/graphic assets for the website.

--- a/.github/www/scripts/README.md
+++ b/.github/www/scripts/README.md
@@ -1,0 +1,41 @@
+# www scripts
+
+Helper scripts used when publishing WSTG content to
+[OWASP/www-project-web-security-testing-guide](https://github.com/OWASP/www-project-web-security-testing-guide).
+
+## generate_nav.py
+
+Builds the website sidebar navigation from `document/README.md`.
+
+**Outputs (as requested by flags):**
+
+- Nested YAML for `_data/<collection>.yaml` (`docs` tree with optional `hints`)
+- Pre-rendered HTML tree for `_includes/nav-tree-<collection>.html`
+  (avoids Liquid `Nesting too deep` from recursive includes)
+- Optional chapter-only markdown ToC for the collection landing page
+
+**Filter hints (A + B):**
+
+- **A.** Title alias rules (e.g. Cross Site Scripting → `xss`, XML Injection → `xxe`,
+  XPath → `xml` / `xpathi`, SQL Injection → `sqli`)
+- **B.** Primary `WSTG-*-*` IDs scraped from each page’s header ID table
+  (first ~40 lines), plus short forms (`WSTG-INPV-01` → `inpv-01`)
+
+Hints are emitted as `data-hints` on each nav item; the site JS matches filter
+input against `data-title` and `data-hints`.
+
+**Usage:**
+
+```bash
+python3 .github/www/scripts/generate_nav.py document/README.md \
+  --title "WSTG Contents" \
+  --collection latest \
+  --yaml-out /path/to/www/_data/latest.yaml \
+  --html-out /path/to/www/_includes/nav-tree-latest.html \
+  --chapter-toc-out /tmp/wstg-chapter-toc.md
+```
+
+`--doc-root` defaults to the README’s parent directory (`document/`). Override
+when scraping IDs from a different content tree (e.g. a versioned www folder).
+
+Invoked by `www_latest_update.yml` and `www_stable_update.yml`.

--- a/.github/www/scripts/generate_nav.py
+++ b/.github/www/scripts/generate_nav.py
@@ -11,6 +11,69 @@ from pathlib import Path
 TOC_ENTRY = re.compile(
     r"^(#{2,5})\s+(?:([0-9.]+|[A-Za-z][A-Za-z0-9. ]*?)\s+)?\[(.*?)\]\((.*?)\)\s*$"
 )
+WSTG_ID_RE = re.compile(r"WSTG-[A-Z]+-\d+", re.IGNORECASE)
+
+# Title substring/regex → filter aliases (A). Applied case-insensitively to titles.
+TITLE_HINT_RULES: list[tuple[re.Pattern[str], list[str]]] = [
+    (re.compile(r"cross[\s-]*site[\s-]*scripting"), ["xss"]),
+    (re.compile(r"dom[\s-]*based"), ["dom xss", "domxss"]),
+    (re.compile(r"sql[\s-]*injection"), ["sqli"]),
+    (re.compile(r"no[\s-]*sql"), ["nosqli"]),
+    (re.compile(r"ldap[\s-]*injection"), ["ldapi"]),
+    # XML family: titles say "XML Injection" / "XPath Injection", not XXE.
+    (re.compile(r"xml[\s-]*injection"), ["xxe", "xmli", "xml injection"]),
+    (re.compile(r"xpath"), ["xpathi", "xml"]),
+    (re.compile(r"ssi[\s-]*injection|server[\s-]*side[\s-]*include"), ["ssi injection"]),
+    (re.compile(r"cross[\s-]*site[\s-]*request[\s-]*forgery"), ["csrf", "xsrf"]),
+    (re.compile(r"server[\s-]*side[\s-]*request[\s-]*forgery"), ["ssrf"]),
+    (re.compile(r"server[\s-]*side[\s-]*template[\s-]*injection"), ["ssti"]),
+    (re.compile(r"client[\s-]*side[\s-]*template[\s-]*injection"), ["csti"]),
+    (re.compile(r"multi[\s-]*factor[\s-]*authentication"), ["mfa", "2fa", "totp"]),
+    (re.compile(r"broken[\s-]*object[\s-]*level[\s-]*authorization"), ["bola", "idor"]),
+    (re.compile(r"broken[\s-]*function[\s-]*level[\s-]*authorization"), ["bfla"]),
+    (re.compile(r"transport[\s-]*layer[\s-]*security"), ["tls", "ssl", "https"]),
+    (re.compile(r"encrypted[\s-]*channel"), ["tls", "ssl", "https"]),
+    (re.compile(r"unencrypted[\s-]*channel"), ["tls", "ssl", "https", "cleartext"]),
+    (re.compile(r"response[\s-]*splitting"), ["crlf", "response splitting"]),
+    (re.compile(r"\bcookie"), ["cookies", "set-cookie", "httponly", "samesite", "secure flag"]),
+    (re.compile(r"cloud[\s-]*storage"), ["s3", "bucket", "blob storage"]),
+    (re.compile(r"directory[\s-]*traversal"), ["path traversal", "dotdot", "lfi"]),
+    (re.compile(r"sql[\s-]*server"), ["mssql", "sql server"]),
+    (re.compile(r"ria[\s-]*cross[\s-]*domain|cross[\s-]*domain[\s-]*policy"), ["crossdomain.xml", "clientaccesspolicy"]),
+    (re.compile(r"web[\s-]*messaging"), ["postmessage", "post message"]),
+    (re.compile(r"reverse[\s-]*tabnabbing"), ["tabnabbing", "window.opener"]),
+    (re.compile(r"clickjacking"), ["ui redress", "ui redressing", "x-frame-options", "framing"]),
+    (re.compile(r"process[\s-]*timing"), ["race condition", "toctou"]),
+    (re.compile(r"metafiles"), ["robots", "robots.txt", "sitemap", "sitemap.xml"]),
+    (re.compile(r"lock[\s-]*out"), ["rate limit", "bruteforce", "brute force", "account lockout"]),
+    (re.compile(r"number[\s-]*of[\s-]*times[\s-]*a[\s-]*function|function[\s-]*can[\s-]*be[\s-]*used"), ["rate limit", "bruteforce", "brute force"]),
+    (re.compile(r"content[\s-]*security[\s-]*policy"), ["csp", "headers"]),
+    (re.compile(r"http[\s-]*strict[\s-]*transport[\s-]*security"), ["hsts", "headers"]),
+    (re.compile(r"json[\s-]*web[\s-]*token"), ["jwt"]),
+    (re.compile(r"cross[\s-]*origin[\s-]*resource[\s-]*sharing"), ["cors", "headers"]),
+    (re.compile(r"security[\s-]*header"), ["headers"]),
+    (re.compile(r"cross[\s-]*site[\s-]*script[\s-]*inclusion"), ["xssi"]),
+    (re.compile(r"file[\s-]*inclusion"), ["lfi", "rfi"]),
+    (re.compile(r"command[\s-]*injection"), ["rce", "cmdi", "os command"]),
+    (re.compile(r"code[\s-]*injection"), ["rce"]),
+    (re.compile(r"http[\s-]*parameter[\s-]*pollution"), ["hpp"]),
+    (re.compile(r"http[\s-]*verb[\s-]*tampering"), ["verb tampering"]),
+    (re.compile(r"format[\s-]*string"), ["format string bug"]),
+    (re.compile(r"csv[\s-]*injection"), ["formula injection"]),
+    (re.compile(r"prototype[\s-]*pollution"), ["pp"]),
+    (re.compile(r"mass[\s-]*assignment"), ["mass assign"]),
+    (re.compile(r"padding[\s-]*oracle"), ["padding oracle attack"]),
+    (re.compile(r"\bgraphql\b"), ["gql"]),
+    (re.compile(r"\boauth\b"), ["oauth2"]),
+    (re.compile(r"open[\s-]*redirect|url[\s-]*redirect"), ["open redirect"]),
+    (re.compile(r"insecure[\s-]*direct[\s-]*object"), ["idor"]),
+    (re.compile(r"privilege[\s-]*escalation"), ["privesc"]),
+    (re.compile(r"request[\s-]*smuggling"), ["http smuggling"]),
+    (re.compile(r"host[\s-]*header"), ["host header injection", "headers"]),
+    (re.compile(r"imap|smtp"), ["email injection"]),
+    (re.compile(r"websocket"), ["ws"]),
+    (re.compile(r"browser[\s-]*storage"), ["localstorage", "sessionstorage"]),
+]
 
 
 def normalize_url(url: str) -> str:
@@ -58,6 +121,93 @@ def parse_toc(text: str) -> list[dict]:
     return roots
 
 
+def resolve_doc_path(doc_root: Path, nav_url: str) -> Path | None:
+    """Map a nav url to a markdown file under doc_root."""
+    path = nav_url.split("#", 1)[0]
+    if not path:
+        return None
+    candidates: list[Path] = []
+    if path.endswith("/"):
+        candidates.append(doc_root / path / "README.md")
+        candidates.append(doc_root / path.rstrip("/") / "README.md")
+    else:
+        candidates.append(doc_root / f"{path}.md")
+        if path.endswith("README"):
+            candidates.append(doc_root / f"{path}.md")
+        else:
+            candidates.append(doc_root / path / "README.md")
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def extract_primary_ids(text: str) -> list[str]:
+    """
+    Collect WSTG IDs from the page header/ID table (first ~40 lines).
+
+    Avoids picking up cross-references later in the body.
+    """
+    head = "\n".join(text.splitlines()[:40])
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in WSTG_ID_RE.findall(head):
+        canonical = match.upper()
+        if canonical not in seen:
+            seen.add(canonical)
+            found.append(canonical)
+    return found
+
+
+def hints_from_title(title: str) -> list[str]:
+    lowered = title.lower()
+    hints: list[str] = []
+    for pattern, aliases in TITLE_HINT_RULES:
+        if pattern.search(lowered):
+            hints.extend(aliases)
+    return hints
+
+
+def hints_from_ids(ids: list[str]) -> list[str]:
+    hints: list[str] = []
+    for test_id in ids:
+        lower = test_id.lower()
+        hints.append(lower)
+        # WSTG-INPV-01 → inpv-01
+        parts = lower.split("-", 1)
+        if len(parts) == 2:
+            hints.append(parts[1])
+    return hints
+
+
+def build_hints(node: dict, doc_root: Path) -> list[str]:
+    hints = hints_from_title(node["title"])
+    doc_path = resolve_doc_path(doc_root, node["url"])
+    if doc_path is not None:
+        text = doc_path.read_text(encoding="utf-8", errors="replace")
+        hints.extend(hints_from_ids(extract_primary_ids(text)))
+    # De-dupe, preserve order, drop empties.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for hint in hints:
+        key = hint.strip().lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        unique.append(key)
+    return unique
+
+
+def attach_hints(nodes: list[dict], doc_root: Path) -> None:
+    for node in nodes:
+        hints = build_hints(node, doc_root)
+        if hints:
+            node["hints"] = hints
+        children = node.get("children") or []
+        if children:
+            attach_hints(children, doc_root)
+
+
 def yaml_escape(value: str) -> str:
     return value.replace("'", "''")
 
@@ -69,6 +219,10 @@ def emit_yaml_nodes(nodes: list[dict], indent: int = 0) -> list[str]:
     for node in nodes:
         lines.append(f"{pad}- title: '{yaml_escape(node['title'])}'")
         lines.append(f"{child_pad}url: {node['url']}")
+        hints = node.get("hints") or []
+        if hints:
+            # Space-separated; quoted so YAML stays a single string.
+            lines.append(f"{child_pad}hints: '{yaml_escape(' '.join(hints))}'")
         children = node.get("children") or []
         if children:
             lines.append(f"{child_pad}children:")
@@ -120,7 +274,11 @@ def emit_html_nodes(nodes: list[dict], collection: str) -> list[str]:
         url = html.escape(node["url"], quote=True)
         href = base + url
         children = node.get("children") or []
-        lines.append(f'<li class="wstg-nav-item" data-title="{title}">')
+        hints = node.get("hints") or []
+        hints_attr = (
+            f' data-hints="{html.escape(" ".join(hints), quote=True)}"' if hints else ""
+        )
+        lines.append(f'<li class="wstg-nav-item" data-title="{title}"{hints_attr}>')
         if children:
             lines.append("<details>")
             lines.append("<summary>")
@@ -167,6 +325,11 @@ def main() -> None:
         help="Site collection folder name (latest, stable, v42, ...)",
     )
     parser.add_argument(
+        "--doc-root",
+        type=Path,
+        help="Root of markdown content for ID scraping (default: readme parent)",
+    )
+    parser.add_argument(
         "--yaml-out",
         type=Path,
         required=True,
@@ -188,6 +351,9 @@ def main() -> None:
     nodes = parse_toc(text)
     if not nodes:
         raise SystemExit(f"No ToC entries parsed from {args.readme}")
+
+    doc_root = args.doc_root if args.doc_root is not None else args.readme.parent
+    attach_hints(nodes, doc_root)
 
     args.yaml_out.parent.mkdir(parents=True, exist_ok=True)
     args.yaml_out.write_text(generate_yaml(args.title, nodes), encoding="utf-8")


### PR DESCRIPTION
## Summary
- Extend `generate_nav.py` to emit filter `hints` from title aliases (xss, sqli, xxe, mfa, bola, …) and scraped `WSTG-*` IDs
- Document nav generation in `.github/www` and workflow READMEs

Companion UI PR: https://github.com/OWASP/www-project-web-security-testing-guide/pull/572