### PR TITLE
fix(web): use root baseurl for wstg.owasp.org

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,5 +1,5 @@
 # Build website/ from master and publish the static site to the gh_pages branch.
-# Preview: https://owasp.github.io/wstg/
+# Live: https://wstg.owasp.org/
 #
 # Similar to www_latest_update / www_stable_update: master holds guide + site
 # source; the published artifact is pushed elsewhere (here: gh_pages).

--- a/website/README.md
+++ b/website/README.md
@@ -4,7 +4,7 @@ Preview site for the Web Security Testing Guide. Source guide content lives in
 `../document/` (latest) and release tags (stable / v4.x). This directory is the
 Jekyll shell (VWAD-inspired L&F).
 
-Published preview: `https://owasp.github.io/wstg/`
+Published preview: `https://wstg.owasp.org/`
 
 ## Branch roles
 
@@ -50,7 +50,7 @@ From the repository root:
 python3 website/scripts/prepare_site.py
 ```
 
-Then open `http://127.0.0.1:4000/wstg/`.
+Then open `http://127.0.0.1:4000/`.
 
 Requires Ruby 3.3+ (script defaults to `RBENV_VERSION=3.3.10`), Bundler, and
 git tags `v4.1` / `v4.2` available locally for versioned channels.

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -2,8 +2,8 @@ title: OWASP Web Security Testing Guide
 description: >-
   The premier cybersecurity testing resource for web application developers
   and security professionals.
-url: "https://owasp.github.io"
-baseurl: "/wstg"
+url: "https://wstg.owasp.org"
+baseurl: ""
 
 # Canonical stable version path (with period). Used by channel banners.
 stable_version: v4.2

--- a/website/serve.sh
+++ b/website/serve.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Prepare channel content and serve the Jekyll site locally.
-# Open: http://127.0.0.1:4000/wstg/
+# Open: http://127.0.0.1:4000/
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -16,4 +16,4 @@ if [[ ! -d vendor/bundle ]]; then
   bundle install
 fi
 
-exec bundle exec jekyll serve --baseurl /wstg --livereload --host 127.0.0.1
+exec bundle exec jekyll serve --livereload --host 127.0.0.1


### PR DESCRIPTION
## Summary
- Set `url` to `https://wstg.owasp.org` and `baseurl` to `""` so CSS/JS/images and channel links stop requesting `/wstg/...` (404 on the custom domain).
- Align local `serve.sh` and docs with root paths.