### PR TITLE
ci(web): set Pages CNAME and document gh-pages branch

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,8 +1,8 @@
-# Build website/ from master and publish the static site to the gh_pages branch.
+# Build website/ from master and publish the static site to the gh-pages branch.
 # Live: https://wstg.owasp.org/
 #
 # Similar to www_latest_update / www_stable_update: master holds guide + site
-# source; the published artifact is pushed elsewhere (here: gh_pages).
+# source; the published artifact is pushed elsewhere (here: gh-pages).
 name: Deploy WSTG website
 
 on:
@@ -53,11 +53,14 @@ jobs:
           JEKYLL_ENV: production
         run: bundle exec jekyll build
 
-      - name: Publish to gh_pages
+      - name: Publish to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/_site
+          publish_branch: gh-pages
+          # Keeps Pages custom domain association across orphan publishes.
+          cname: wstg.owasp.org
           # Prebuilt HTML; do not let GitHub run Jekyll on the branch.
           enable_jekyll: false
           force_orphan: true

--- a/website/README.md
+++ b/website/README.md
@@ -11,9 +11,9 @@ Published preview: `https://wstg.owasp.org/`
 | Branch | Role |
 |--------|------|
 | `master` | Guide (`document/`) plus this site **source** and deploy workflow (same idea as `.github/www` + `www_*_update` workflows). |
-| `gh_pages` | **Built** static site only. Written by `.github/workflows/deploy-website.yml` (do not hand-edit). |
+| `gh-pages` | **Built** static site only. Written by `.github/workflows/deploy-website.yml` (do not hand-edit). |
 
-GitHub Pages should deploy from branch **`gh_pages`** / root (not “GitHub Actions”).
+GitHub Pages should deploy from branch **`gh-pages`** / root (not “GitHub Actions”), with custom domain `wstg.owasp.org`.
 
 ## Channels
 


### PR DESCRIPTION
## Summary
- Publish explicitly to `gh-pages` and set `cname: wstg.owasp.org` so orphan deploys keep the custom-domain CNAME file.
- Correct docs that said `gh_pages` (underscore).

Still set **Settings → Pages → Custom domain** to `wstg.owasp.org` once if the UI does not already show it (`cname` was null on the API).