### PR TITLE
fix(web): rewrite leaf sibling links for pretty URLs

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
@@ -290,7 +290,7 @@ Remember that Ad Hoc Distributed Queries and `OPENROWSET` have been restricted s
 
 - [David Litchfield: "Data-mining with SQL Injection and Inference"](https://dl.packetstormsecurity.net/papers/attack/sqlinference.pdf)
 - [Chris Anley, "(more) Advanced SQL Injection"](https://www.cgisecurity.com/lib/more_advanced_sql_injection.pdf)
-- [Alexander Chigrik: "Useful undocumented extended stored procedures"](https://www.databasejournal.com/features/mssql/article.php/1441251/Useful-Undocumented-Extended-Stored-Procedures.htm)
+- [Alexander Chigrik: "Useful undocumented extended stored procedures"](https://www.databasejournal.com/ms-sql/useful-undocumented-extended-stored-procedures/)
 - [Antonin Foller: "Custom xp_cmdshell, using shell object"](https://www.motobit.com/tips/detpg_cmdshell)
 - [SQL Injection](https://www.cisecurity.org/wp-content/uploads/2017/05/SQL-Injection-White-Paper.pdf)
 - [Cesar Cerrudo: Manipulating Microsoft SQL Server Using SQL Injection, uploading files, getting into internal network, port scanning, DOS](https://www.cgisecurity.com/lib/Manipulating_SQL_Server_Using_SQL_Injection.pdf)

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
@@ -197,7 +197,7 @@ Other options for out of band attacks are described in [Sample 4 above](#example
 
 #### Trial and Error
 
-Alternatively, one may play lucky. That is the attacker may assume that there is a blind or out-of-band SQL injection vulnerability in a the web application. He will then select an attack vector (e.g., a web entry), [use fuzz vectors](../../6-Appendix/C-Fuzz_Vectors.md) against this channel and watch the response. For example, if the web application is looking for a book using a query
+Alternatively, one may play lucky. That is the attacker may assume that there is a blind or out-of-band SQL injection vulnerability in a the web application. He will then select an attack vector (e.g., a web entry), [use fuzz vectors](../../6-Appendix/C-Fuzzing.md) against this channel and watch the response. For example, if the web application is looking for a book using a query
 
 ```sql
 select * from books where title="text entered by the user"

--- a/website/README.md
+++ b/website/README.md
@@ -29,8 +29,9 @@ GitHub Pages should deploy from branch **`gh-pages`** / root (not “GitHub Acti
 `CURRENT_STABLE` in `scripts/prepare_site.py` when the current release changes.
 
 Prepare also rewrites Markdown for the site: strip `.md` from links, map
-`README` → directory URLs, fix sibling `images/` paths on leaf pages, and turn
-`README.md` files into redirects to their directory index.
+`README` → directory URLs, fix leaf-page relative links (siblings and
+`images/` need `../` under pretty permalinks), and turn `README.md` files
+into redirects to their directory index.
 
 Canonical version URLs use a **period** (`v4.1`). The old owasp.org publish
 pipeline stripped periods (`v41`) for path/data-key safety; this site keeps

--- a/website/README.md
+++ b/website/README.md
@@ -29,9 +29,9 @@ GitHub Pages should deploy from branch **`gh-pages`** / root (not “GitHub Acti
 `CURRENT_STABLE` in `scripts/prepare_site.py` when the current release changes.
 
 Prepare also rewrites Markdown for the site: strip `.md` from links, map
-`README` → directory URLs, fix leaf-page relative links (siblings and
-`images/` need `../` under pretty permalinks), and turn `README.md` files
-into redirects to their directory index.
+`README` → directory URLs, add one extra `../` on leaf pages (pretty
+permalinks nest `/Page/` one level deeper than the repo file), lowercase
+fragments, and turn `README.md` files into redirects to their directory index.
 
 Canonical version URLs use a **period** (`v4.1`). The old owasp.org publish
 pipeline stripped periods (`v41`) for path/data-key safety; this site keeps

--- a/website/scripts/prepare_site.py
+++ b/website/scripts/prepare_site.py
@@ -103,12 +103,17 @@ def rewrite_site_href(href: str, md_path: Path) -> str:
     if href == "README" or href.endswith("/README"):
         href = href[: -len("README")] or "./"
 
-    # Leaf pages render as /path/Page/; sibling images/ is one level up.
+    # Leaf pages render as /path/Page/; relative targets that were siblings in
+    # the repo (same folder .md files, images/) must go up one level.
     if md_path.name.lower() not in ("readme.md", "index.md"):
-        if href.startswith("images/") or href.startswith("./images/"):
-            parent_images = md_path.parent / "images"
-            if parent_images.is_dir():
-                href = "../" + href.removeprefix("./")
+        if href.startswith("./"):
+            href = href[2:]
+        if href and not href.startswith("../") and not href.startswith("/"):
+            href = "../" + href
+
+    # Pretty permalinks expect a trailing slash on directory-style paths.
+    if href and not href.endswith("/") and "." not in Path(href).name:
+        href += "/"
 
     return href + frag
 

--- a/website/scripts/prepare_site.py
+++ b/website/scripts/prepare_site.py
@@ -84,12 +84,23 @@ def prepend_front_matter(path: Path, matter: str) -> None:
 # Markdown hrefs that should not be rewritten (scheme / fragment-only / protocol-relative).
 _SKIP_HREF = re.compile(r"^(?:[a-z][a-z0-9+.-]*:|#|//)", re.IGNORECASE)
 _MD_LINK = re.compile(r"\]\(([^)]+)\)")
+# Real file assets keep their extension; dotted scenario names (05.1-foo) do not.
+_ASSET_EXT = re.compile(
+    r"\.(?:png|jpe?g|gif|svg|webp|pdf|html?|css|js)$", re.IGNORECASE
+)
 
 
 def rewrite_site_href(href: str, md_path: Path) -> str:
     """Adapt repo-relative markdown/image hrefs for Jekyll pretty permalinks."""
     href = href.strip()
-    if not href or _SKIP_HREF.match(href):
+    if not href:
+        return href
+
+    # Same-page anchors: kramdown ids are lowercase.
+    if href.startswith("#"):
+        return "#" + href[1:].lower()
+
+    if _SKIP_HREF.match(href):
         return href
 
     frag = ""
@@ -103,16 +114,18 @@ def rewrite_site_href(href: str, md_path: Path) -> str:
     if href == "README" or href.endswith("/README"):
         href = href[: -len("README")] or "./"
 
-    # Leaf pages render as /path/Page/; relative targets that were siblings in
-    # the repo (same folder .md files, images/) must go up one level.
+    # Leaf pages render as /path/Page/ (one directory deeper than the .md file's
+    # folder). Every repo-relative href needs one extra ../ — same-folder
+    # siblings (01-foo.md, images/x.png) and existing ../cross/folder links.
     if md_path.name.lower() not in ("readme.md", "index.md"):
         if href.startswith("./"):
             href = href[2:]
-        if href and not href.startswith("../") and not href.startswith("/"):
+        if href and not href.startswith("/"):
             href = "../" + href
 
     # Pretty permalinks expect a trailing slash on directory-style paths.
-    if href and not href.endswith("/") and "." not in Path(href).name:
+    # Do not treat dotted scenario slugs (05.1-foo) as file assets.
+    if href and not href.endswith("/") and not _ASSET_EXT.search(href):
         href += "/"
 
     return href + frag


### PR DESCRIPTION
## Summary
Leaf guide pages publish as `/…/Page/`, one level deeper than the repo `.md` file. Prepare now prefixes **one extra `../`** on every repo-relative content href from leaf pages (siblings, `images/`, and existing `../…` cross-folder links), lowercases fragments, and adds trailing `/` (including dotted slugs like `05.1-…`).

Also fixes one broken guide link: `C-Fuzz_Vectors.md` → `C-Fuzzing.md`.

### Audit (document/)
| Kind | Count | Notes |
|------|------:|-------|
| Leaf same-dir `.md` | 56 | fixed by +`../` |
| Leaf `images/` | 56 | fixed by +`../` |
| Leaf `../` cross-page | 115 | need +extra `../` (was still wrong after sibling-only fix) |
| Leaf `../../` | 2 | become `../../../` |
| README-relative | ~330 | unchanged (correct at dir URL) |
| Same-page `#` | 36 | already lowercase |
| Cross-page `#Frag` | 17 | lowercased on rewrite |
| HTML `<img>` | 1 | external URL only |