### PR TITLE
Fix malformed scheme on the Syhunt NoSQL/SSJS Injection reference

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.md
@@ -68,7 +68,7 @@ One way to potentially assign data to PHP variables is via HTTP Parameter Pollut
 
 - [Bryan Sullivan from Adobe: "NoSQL, But Even Less Security"](https://repository.root-me.org/Exploitation%20-%20Web/EN%20-%20NoSQL%20But%20Even%20Less%20Security.pdf)
 - [Erlend from Bekk Consulting: Security NOSQL-injection](https://erlend.oftedal.no/blog/?blogid=110)
-- [Felipe Aragon from Syhunt: "NoSQL/SSJS Injection"](hhttps://www.syhunt.com/en/?n=Articles.NoSQLInjection)
+- [Felipe Aragon from Syhunt: "NoSQL/SSJS Injection"](https://www.syhunt.com/en/?n=Articles.NoSQLInjection)
 - [MongoDB Documentation: "How does MongoDB address SQL or Query injection?"](https://docs.mongodb.org/manual/faq/developers/#how-does-mongodb-address-sql-or-query-injection)
 - [PHP Documentation: "MongoDB Driver Classes"](https://www.php.net/manual/en/book.mongodb.php)
 - [Hacking NodeJS and MongoDB](https://blog.websecurify.com/2014/08/hacking-nodejs-and-mongodb.html)


### PR DESCRIPTION
- [x] You have validated the need for this change.
- [x] If this PR is one of several related changes, note what remains. See below.

**What did this PR accomplish?**

- Fixes the scheme on the Syhunt whitepaper reference in `05.6-Testing_for_NoSQL_Injection.md`, which read `hhttps://` and so never resolved.
- Verified: `https://www.syhunt.com/en/?n=Articles.NoSQLInjection` returns HTTP 200.

**Related finding, not fixed here**

I found this by resolving every relative and malformed link target in the repository, and it turned up a second one of the same shape that I do not think I should fix unilaterally.

`document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection.md` line 110:

```md
- [Sacha Faust: LDAP Injection: Are Your Applications Vulnerable?](httphttps://www.networkdls.com/articles/ldapinjection.pdf)
```

Correcting `httphttps://` to `https://` is not enough, because the target is gone. What I checked:

- `https://www.networkdls.com/articles/ldapinjection.pdf` returns 404
- `https://www.networkdls.com/Articles/LDAPinjection.pdf`, the casing the Wayback record uses, also returns 404
- I could not find a live copy on another host
- the Wayback availability API reports a 200 snapshot from 2024-06-30, but web.archive.org is unreachable from where I am testing, so I have not opened it myself and will not cite a snapshot I have not read

So that one needs an editorial decision rather than a link fix: point it at an archive snapshot, swap in a different reference, or drop the entry. Happy to open a follow-up PR for whichever you prefer.

The only other things the sweep flagged were two root-relative links in `Testing_for_APIs.md`, which I have raised separately, and one example inside a fenced code block in `style_guide.md`, which is correct as written.

Drafted with AI assistance; I verified each URL and file path myself.
