### PR TITLE
Fix the two root-relative JWT cross-references in Testing_for_APIs.md

### DIFF
--- a/Testing_for_APIs.md
+++ b/Testing_for_APIs.md
@@ -72,14 +72,14 @@ Step 2: Exploit bugs - As know how to list endpoints and examine endpoints with 
 
 Token-based authentication is implemented by sending a signed token (verified by the server) with each HTTP request.
 
-The most commonly used token format is the JSON Web Token (JWT), defined in [RFC7519](https://tools.ietf.org/html/rfc7519). The [Testing JSON Web Tokens](/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md) guide contains further details on how to test JWTs.
+The most commonly used token format is the JSON Web Token (JWT), defined in [RFC7519](https://tools.ietf.org/html/rfc7519). The [Testing JSON Web Tokens](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md) guide contains further details on how to test JWTs.
 
 ## Related Test Cases
 
 - [IDOR](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References.md)
 - [Privilege escalation](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation.md)
 - All [Session Management](https://github.com/OWASP/wstg/tree/master/document/4-Web_Application_Security_Testing/06-Session_Management_Testing) test cases
-- [Testing JSON Web Tokens](/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md)
+- [Testing JSON Web Tokens](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md)
 
 ## Tools
 


### PR DESCRIPTION
- [x] You have validated the need for this change.
- [x] If this PR is one of several related changes, note what remains. See below.

**What did this PR accomplish?**

- Fixes the two JWT cross-references in `Testing_for_APIs.md`, lines 75 and 82. Both were root-relative:

  ```md
  [Testing JSON Web Tokens](/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens.md)
  ```

  A leading `/` resolves against the host, so on GitHub these went to `github.com/document/...` and returned 404 rather than to the file in this repository.

- Uses the full `https://github.com/OWASP/wstg/blob/master/...` form, which is what the other three cross-references in the same file already use, including the one in the very same `Related Test Cases` list. The target file exists at that path.

**Related, not in this PR**

Same sweep also turned up two malformed link schemes in the Input Validation chapter. The Syhunt one is fixed in #1481; the LDAP one needs an editorial decision because its target is gone, and I have described what I checked there rather than guessing at a replacement.

Drafted with AI assistance; I verified the target path and the surrounding link convention in the file myself.
