### PR TITLE
Correct duplicated words and article errors in seven test chapters

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
@@ -117,9 +117,9 @@ Let's disassemble what we did in this string:
 
 ### PHP Magic Hashes
 
-A similar issue can occur in PHP when hashes are are loosely compared, and end up being evaluated as numbers.
+A similar issue can occur in PHP when hashes are loosely compared, and end up being evaluated as numbers.
 
-PHP supports the use of [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) for numbers, so the number `2e4` is treated as "two times ten to the power of four", which equals 20,000. Similarly, a number such as `0e4` would be "zero times ten to the power of four", which equals zero. Because zero times anything is zero, this means that an comparison such as `0e2 == 0e3` would evaluate to true, because both sides equal zero.
+PHP supports the use of [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) for numbers, so the number `2e4` is treated as "two times ten to the power of four", which equals 20,000. Similarly, a number such as `0e4` would be "zero times ten to the power of four", which equals zero. Because zero times anything is zero, this means that a comparison such as `0e2 == 0e3` would evaluate to true, because both sides equal zero.
 
 This can be exploitable where two password hashes are compared, and both of them are in the form of string of zeros, the letter "e", and then a string of numbers. Consider the following code:
 

--- a/document/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema.md
+++ b/document/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema.md
@@ -41,7 +41,7 @@ When a web application does not properly enforce access control mechanisms, sens
 
 This process can be automated if you have a list of all endpoints with tools like ffuf, gobuster, ZAP, and Burp Suite Intruder.
 
-For ZAP, using a adddon for [Access Control Testing](https://www.zaproxy.org/docs/desktop/addons/access-control-testing/) allows testers to determine which parts of the application are available to anonymous users, and identify potential access control issues.
+For ZAP, using an add-on for [Access Control Testing](https://www.zaproxy.org/docs/desktop/addons/access-control-testing/) allows testers to determine which parts of the application are available to anonymous users, and identify potential access control issues.
 
 For Burp Suite, built-in tools such as Intruder, and a number of plugins, including Autorize, help the tester automate testing authorization.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection.md
@@ -79,7 +79,7 @@ The following examples can be used.
 
 The final result of the above testing gives the tester three possible situations:
 
-1. The application returns a error code/message
+1. The application returns an error code/message
 2. The application does not return an error code/message, but it does not realize the requested operation
 3. The application does not return an error code/message and realizes the operation requested normally
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection.md
@@ -180,7 +180,7 @@ Here is a methodology we can use when we come across a filter:
 
 - Is the filter client-side or server-side ?
 - Is the filter applied on special characters, OS commands, or both ?
-- Is the webapp using a allowlist or blocklist filter ?
+- Is the webapp using an allowlist or blocklist filter ?
 - What OS is running on the web server? This allows us to have an idea of the commands and special characters we can use.
 
 ### Special Characters Filter Evasion

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse.md
@@ -88,7 +88,7 @@ During testing, assess whether:
 
 These defenses work best in authenticated parts of the application, although rate of creation of new accounts or accessing content (e.g. to scrape information) can be of use in public areas.
 
-Not all the above need to be monitored by the application, but there is a problem if none of them are. By testing the web application, doing the above type of actions, was any response taken against the tester? If not, the tester should report that the application appears to have no application-wide active defenses against misuse. Note it is sometimes possible that all responses to attack detection are silent to the user (e.g. logging changes, increased monitoring, alerts to administrators and and request proxying), so confidence in this finding cannot be guaranteed. In practice, very few applications (or related infrastructure such as a web application firewall) are detecting these types of misuse.
+Not all the above need to be monitored by the application, but there is a problem if none of them are. By testing the web application, doing the above type of actions, was any response taken against the tester? If not, the tester should report that the application appears to have no application-wide active defenses against misuse. Note it is sometimes possible that all responses to attack detection are silent to the user (e.g. logging changes, increased monitoring, alerts to administrators and request proxying), so confidence in this finding cannot be guaranteed. In practice, very few applications (or related infrastructure such as a web application firewall) are detecting these types of misuse.
 
 ## Related Test Cases
 

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/10-Test-Payment-Functionality.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/10-Test-Payment-Functionality.md
@@ -157,7 +157,7 @@ If it's not possible to tamper with the actual prices, it may be possible to cha
 
 #### Time Delayed Requests
 
-If the value of items on the site changes over time (for example on a currency exchange), then it may be possible to buy or sell at an old price by intercepting requests using a local proxy and delaying them. In order for this to be exploitable, the price would need to either be included in the request, or linked to something in the request (such as session or transaction ID). The example below shows how this could potentially be exploited on a application that allows users to buy and sell gold:
+If the value of items on the site changes over time (for example on a currency exchange), then it may be possible to buy or sell at an old price by intercepting requests using a local proxy and delaying them. In order for this to be exploitable, the price would need to either be included in the request, or linked to something in the request (such as session or transaction ID). The example below shows how this could potentially be exploited on an application that allows users to buy and sell gold:
 
 - View the current price of gold on the site.
 - Initiate a buy request for 1oz of gold.

--- a/document/4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance.md
+++ b/document/4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance.md
@@ -83,7 +83,7 @@ Browsing the application with an intercepting proxy such as ZAP or Burp Suite re
 - `https://example.com/api/v1` (or v2 etc)  
 - `https://example.com/graphql`
 
-Or subdomains the the applications may consume or depend upon:
+Or subdomains the applications may consume or depend upon:
 
 - `https://api.example.com/api/v1`
 


### PR DESCRIPTION
Eight prose defects, found by sweeping the guide for repeated words and mismatched indefinite articles, then reading each hit in context.

| File | Was | Now |
| --- | --- | --- |
| Bypassing Authentication Schema | hashes **are are** loosely compared | are loosely compared |
| Bypassing Authentication Schema | **an** comparison such as `0e2 == 0e3` | a comparison |
| Bypassing Authorization Schema | using **a adddon** for Access Control Testing | an add-on |
| IMAP/SMTP Injection | returns **a error** code/message | an error code/message |
| Command Injection | using **a allowlist** or blocklist filter | an allowlist |
| Test Defenses Against Application Misuse | administrators **and and** request proxying | and request proxying |
| Test Payment Functionality | on **a application** that allows users | an application |
| API Reconnaissance | subdomains **the the** applications may consume | the applications |

Two notes on judgment calls:

- `a adddon` is both a misspelling and the wrong article. I used `add-on` because this same file already writes it that way at line 195 ("ZAP add-on: Access Control Testing"), as does `01-Test_Role_Definitions.md`.
- `a error code/message` is the first of three consecutive list items; the second and third already read `an error code/message`.

Two sweep hits were deliberately left alone rather than "fixed":

- `the operators AND and OR` in the SQL Injection chapter is correct English, not a duplicated word.
- `"%" HEXDIG HEXDIG` in Naming Schemes is the ABNF production from RFC 3986.

Prose only, no technical content changed. markdownlint-cli2 and textlint (with the repo's own configs) both run clean against the seven changed files locally.
