### PR TITLE
Repoint the dead Session ID Brute Force reference to a Wayback capture

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema.md
@@ -158,4 +158,4 @@ Testing is simple: try and login to an account with a password that is incorrect
 ## References
 
 - [Niels Teusink: phpBB 2.0.12 authentication bypass](http://blog.teusink.net/2008/12/classic-bug-phpbb-2012-authentication.html)
-- [David Endler: "Session ID Brute Force Exploitation and Prediction"](https://www.cgisecurity.com/lib/SessionIDs.pdf)
+- [David Endler: "Session ID Brute Force Exploitation and Prediction"](https://web.archive.org/web/20250711045439/https://www.cgisecurity.com/lib/SessionIDs.pdf)


### PR DESCRIPTION
`https://www.cgisecurity.com/lib/SessionIDs.pdf`, cited in the Bypassing Authentication Schema chapter, returns 404.

cgisecurity.com moved its paper library: `/lib/` now serves a meta-refresh to `/lib.html` ("Security Paper Library page has moved!"), and the relocated index does not list this paper. So there is no current location on that host to point at.

This repoints it to the Internet Archive capture of the original URL, matching how the guide already handles references whose hosts went away, for example [An Introduction to HTTP fingerprinting](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md) and [Session Riding](https://github.com/OWASP/wstg/blob/master/document/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery.md).

I used the 2025-07-11 capture. The Wayback availability API also reports status-200 captures at 2019-07-08 and 2022-09-01 if an older one is preferred.

One caveat I would rather state than paper over: archive.org is currently rate-limiting my network with 429s, so I confirmed the captures exist and are recorded as status 200 through the availability API, but I was not able to download the PDF and eyeball it. The link checker in CI should settle it.

This surfaced on #1484, where the diff-based link check flagged it because that PR touches this file for unrelated typo fixes. The broken link is pre-existing on master, so it seemed cleaner to fix it on its own rather than fold it into a prose-only PR. Happy to reorder or combine them if you would prefer.
