### PR TITLE
Add directive-syntax probes and refresh tooling in the SSTI section

### DIFF
--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection.md
@@ -71,14 +71,14 @@ a{{7*7}}
 {var} ${var} {{var}} <%var%> [% var %]
 ```
 
-Expression syntax is not the only reachable surface. Apache Velocity and FreeMarker also evaluate *directive* syntax, which none of the probes above will trigger. A directive assigns rather than prints, so pair it with an interpolation to make the result observable:
+Expression syntax is not the only reachable surface. Apache Velocity and FreeMarker also evaluate *directive* syntax, which none of the probes above will trigger. An assignment directive stores its result instead of printing it, so pair it with an interpolation to make the value observable:
 
 ```text
 #set($x=7*7)$x
 <#assign x=7*7>${x}
 ```
 
-Both render `49` where the directive was evaluated. Sent without the trailing interpolation they render nothing at all, which matters when building the exploit: a directive such as `<#assign r=ex("id")>` invokes the method and returns no output, so an unchanged response does not mean the payload was not executed. Where output is suppressed, confirm evaluation with an observable side effect instead, such as an out-of-band DNS lookup or a measurable delay.
+Both render `49` where the directive was evaluated. Sent without the trailing interpolation they render nothing at all, which matters when building the exploit: an assignment such as `<#assign result=runner("id")>`, where `runner` is an object instantiated by an earlier directive rather than anything the engine provides, invokes the method and returns no output. An unchanged response is therefore not evidence that the payload was not executed. Where output is suppressed, confirm evaluation with an observable side effect instead, such as an out-of-band DNS lookup or a measurable delay.
 
 In this step an extensive [template expression test strings/payloads list](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Template%20Injection) is recommended.
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection.md
@@ -71,6 +71,15 @@ a{{7*7}}
 {var} ${var} {{var}} <%var%> [% var %]
 ```
 
+Expression syntax is not the only reachable surface. Apache Velocity and FreeMarker also evaluate *directive* syntax, which none of the probes above will trigger. A directive assigns rather than prints, so pair it with an interpolation to make the result observable:
+
+```text
+#set($x=7*7)$x
+<#assign x=7*7>${x}
+```
+
+Both render `49` where the directive was evaluated. Sent without the trailing interpolation they render nothing at all, which matters when building the exploit: a directive such as `<#assign r=ex("id")>` invokes the method and returns no output, so an unchanged response does not mean the payload was not executed. Where output is suppressed, confirm evaluation with an observable side effect instead, such as an out-of-band DNS lookup or a measurable delay.
+
 In this step an extensive [template expression test strings/payloads list](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Template%20Injection) is recommended.
 
 Testing for SSTI in code context is slightly different. First, the tester constructs the request that result either blank or error server responses. In the example below the HTTP GET parameter is inserted info the variable `personal_greeting` in a template statement:
@@ -96,7 +105,7 @@ Hello user01 <tag>
 
 ### Identify the Templating Engine
 
-Based on the information from the previous step now the tester has to identify which template engine is used by supplying various template expressions. Based on the server responses the tester deduces the template engine used. This manual approach is discussed in greater detail in [this](https://portswigger.net/blog/server-side-template-injection?#Identify) PortSwigger article. To automate the identification of the SSTI vulnerability and the templating engine various tools are available including [Tplmap](https://github.com/epinna/tplmap) or the [Backslash Powered Scanner Burp Suite extension](https://github.com/PortSwigger/backslash-powered-scanner).
+Based on the information from the previous step now the tester has to identify which template engine is used by supplying various template expressions. Based on the server responses the tester deduces the template engine used. This manual approach is discussed in greater detail in [this](https://portswigger.net/blog/server-side-template-injection?#Identify) PortSwigger article. To automate the identification of the SSTI vulnerability and the templating engine various tools are available including [SSTImap](https://github.com/vladko312/SSTImap) or the [Backslash Powered Scanner Burp Suite extension](https://github.com/PortSwigger/backslash-powered-scanner).
 
 ### Build the RCE Exploit
 
@@ -111,7 +120,8 @@ The tester can also identify what other objects, methods and properties can be e
 
 ## Tools
 
-- [Tplmap](https://github.com/epinna/tplmap)
+- [SSTImap](https://github.com/vladko312/SSTImap)
+- [Tplmap](https://github.com/epinna/tplmap) - no longer maintained; SSTImap is an actively developed fork
 - [Backslash Powered Scanner Burp Suite extension](https://github.com/PortSwigger/backslash-powered-scanner)
 - [Template expression test strings/payloads list](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Template%20Injection)
 


### PR DESCRIPTION
- [x] You have validated the need for this change.
- [ ] If this PR is one of several related changes, note what remains.

**What did this PR accomplish?**

Two changes to WSTG-INPV-18, both small.

- **Directive syntax added to the detection probes.** Every probe in the section is an interpolation form (`{{ }}`, `${ }`, `<% %>`, `[% %]`). Velocity and FreeMarker also evaluate directive syntax, which none of those probes reach, so a tester working through the list can conclude a Java template surface is not injectable when it is. Adds `#set($x=7*7)$x` and `<#assign x=7*7>${x}`, paired with an interpolation so the result is observable — I checked both render `49` under Velocity 2.3 and FreeMarker 2.3.32 with an empty data model.

    The same paragraph notes something that cost me time when I first hit this: a directive on its own renders nothing. `<#assign r=ex("id")>` invokes the method and returns no output, so an unchanged response is not evidence the payload did not execute. For that case the section now points at an out-of-band side effect rather than a reflected value.

- **Tplmap replaced with SSTImap in the Tools list and in "Identify the Templating Engine".** Tplmap's last commit was 2021-11-03. SSTImap is an actively maintained fork and was last updated in August 2026. Tplmap is kept in the list, marked as unmaintained, since existing write-ups reference it.

Checks run locally against the workflow configs: `markdownlint-cli2 --config .github/configs/.markdownlint.json` reports 0 issues, and `textlint --config .github/configs/.textlintrc.json` exits clean.

Context for the directive gap: I ran into it while testing OWASP CRS coverage for the same syntax ([coreruleset#4773](https://github.com/coreruleset/coreruleset/issues/4773)), where the same blind spot exists on the defensive side.
