### PR TITLE
Fix four dead reference links

### DIFF
--- a/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/document/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -65,7 +65,7 @@ This type of issue is often difficult to identify from a black-box perspective.
 
 - [Burp Intruder](https://portswigger.net/burp/documentation/desktop/tools/intruder)
 - [THC Hydra](https://github.com/vanhauser-thc/thc-hydra)
-- [Nikto 2](https://www.cirt.net/nikto2)
+- [Nikto 2](https://cirt.net/Nikto2)
 - [Nuclei](https://github.com/projectdiscovery/nuclei)
     - [Default Login - Nuclei Templates](https://github.com/projectdiscovery/nuclei-templates/tree/6b26c63d8f63b2a812a478f14c4c098b485d54b4/http/default-logins)
 

--- a/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection.md
+++ b/document/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection.md
@@ -58,4 +58,4 @@ Another example would include the [Laravel Query-Builder](https://laravel.com/do
 - [New Methods for Exploiting ORM Injections in Java Applications (HITB16)](https://insinuator.net/2016/06/new-methods-for-exploiting-orm-injections-in-java-applications-hitb16/)
 - [HITB2016 Slides - ORM Injections in Java Applications](https://archive.conference.hitb.org/hitbsecconf2016ams/sessions/new-methods-for-exploiting-orm-injections-in-java-applications/)
 - [Fixing SQL Injection: ORM is not enough](https://snyk.io/blog/sql-injection-orm-vulnerabilities/)
-- [PayloadsAllTheThings - HQL Injection](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/SQL%20Injection/HQL%20Injection.md)
+- [PayloadsAllTheThings - HQL Injection](https://web.archive.org/web/20240918174724/https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/SQL%20Injection/HQL%20Injection.md)

--- a/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks.md
+++ b/document/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks.md
@@ -73,4 +73,4 @@ The application should follow strict access controls on how data and artifacts c
 - [Implementing Referential Integrity and Shared Business Logic in a RDB](https://agiledata.org/essays/referentialIntegrity.html)
 - [On Rules and Integrity Constraints in Database Systems](https://www.comp.nus.edu.sg/~lingtw/papers/IST92.teopk.pdf)
 - [Use referential integrity to enforce basic business rules in Oracle](https://www.techrepublic.com/article/use-referential-integrity-to-enforce-basic-business-rules-in-oracle/)
-- [Maximizing Business Logic Reuse with Reactive Logic](https://dzone.com/articles/maximizing-business-logic)
+- [Maximizing Business Logic Reuse with Reactive Logic](https://web.archive.org/web/20221116203934/https://dzone.com/articles/maximizing-business-logic)

--- a/document/6-Appendix/D-Fuzzing.md
+++ b/document/6-Appendix/D-Fuzzing.md
@@ -63,4 +63,4 @@ In the examples above we have seen why we need a wordlist. Just wordlists are no
 - [EdOverflow Bug Bounty Cheat Sheet](https://github.com/EdOverflow/bugbounty-cheatsheet)
 - [Daniel Miessler - SecLists](https://github.com/danielmiessler/SecLists)
 - [XssPayloads Twitter Feed](https://twitter.com/XssPayloads)
-- [XssPayloads List](https://github.com/payloadbox/xss-payload-list)
+- [XssPayloads List](https://github.com/payload-box/xss-payload-list)


### PR DESCRIPTION
- [x] You have validated the need for this change.
- [x] If this PR is one of several related changes, note what remains.

**What did this PR accomplish?**

Fixes four reference links that no longer resolve:

- **WSTG-ATHN-02** — `https://www.cirt.net/nikto2` returns 404. The page is served at `https://cirt.net/Nikto2`; the path is case-sensitive.
- **Appendix D (Fuzzing)** — the `payloadbox` account no longer exists. The author has re-published the list at `payload-box/xss-payload-list`, though as a fresh upload rather than the original repository: the archived original carried 7.8k stars and an MIT license, while the new copy dates from January 2026 and declares no license. Happy to point at a Wayback capture of the original instead if you would prefer that.
- **WSTG-INPV-05.7** — `HQL Injection.md` was removed from PayloadsAllTheThings, and the `SQL Injection` directory no longer carries HQL content. Repointed to a Wayback capture.
- **WSTG-BUSL-03** — the DZone article returns `410 Gone`. Repointed to a Wayback capture.

These came out of checking every external link in the repository, so as far as I can tell there are no other dead ones. Worth noting that the two GitHub links could not have been caught by CI, since `^https://github\.com` is in `ignorePatterns`.

Thank you for your contribution!
