### PR TITLE
Ignore baidu.com in the markdown link check

### DIFF
--- a/.github/configs/markdown-link-check-config.json
+++ b/.github/configs/markdown-link-check-config.json
@@ -8,6 +8,7 @@
         { "pattern": "^https://www.kali.org" },
         { "pattern": "^https://.*\\.linkedin\\.com" },
         { "pattern": "^https://www\\.shodan\\.io" },
+        { "pattern": "^https://www\\.baidu\\.com" },
         { "pattern": "^https://developer\\.android\\.com" },
         { "pattern": "^https://github\\.com" }
     ],


### PR DESCRIPTION
Recurring false positive on the link check. Most recently on #1478, but it fires on any PR touching a file that links Baidu.

```
FILE: .../01-Conduct_Search_Engine_Reconnaissance_for_Information_Leakage.md
[❌] https://www.baidu.com/ → Status: 0
```

@kingthorin already called it (*"baidu is being hostile and blocking the action just hanging up on us"*). This just makes the checker agree.

**Why the existing knobs do not cover it**

- `Status: 0` is a connection-level failure — no HTTP status is returned — so `aliveStatusCodes` cannot catch it the way it already catches the `403`/`429` cases.
- `timeout` is not the constraint. From an ordinary network, with the exact `User-Agent` this config sends, `https://www.baidu.com/` answers **200 in ~2.1s**, `connect` 0.48s, ~700KB body — comfortably inside the configured `30s`. The request is being dropped from the runner, not running slow.

So an ignore pattern is the remaining mechanism, and it is what the six existing entries (nstalker, kali.org, linkedin, shodan, developer.android.com, github.com) are there for.

The Baidu link itself is legitimate content — it is cited as China's most popular search engine in the search engine reconnaissance section — so it stays; only the checker changes.

**Two notes for review**

- This will not fix #1478 by itself. The workflow reads the config from `base/` (OWASP/wstg `master`), so the pattern only takes effect once this is on `master`.
- The link-check workflow excludes `.github/**`, so this PR will not run it on itself. I verified the file is still valid JSON locally.