### PR TITLE
docs: Add QUERY method documentation; expand INFO section with overview, examples, and tools

### DIFF
--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/00-Information_Gathering_Overview.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/00-Information_Gathering_Overview.md
@@ -1,0 +1,9 @@
+# Information Gathering Overview
+
+You can only test what you can find. Before a tester can assess authentication, authorization, business logic, or any other area of an application, they must first identify what is actually in scope: the applications, hosts, endpoints, and technologies that make up the attack surface. Assets that are never discovered are never tested, regardless of how thorough the rest of the assessment is.
+
+Information gathering and discovery is therefore the foundation of any web application security assessment. It combines passive reconnaissance (which does not directly interact with the target) with active enumeration (which does) to build as complete a picture as possible of what is exposed, how it is exposed, and what technologies are involved.
+
+Contemporary assessments commonly combine passive subdomain enumeration (`subfinder`, Amass passive), live-host probing (`httpx`), Certificate Transparency, archive URL collection (`gau`, `waybackurls`, `waymore`), JavaScript analysis (`jsluice`, LinkFinder), and targeted content discovery (`ffuf`, `feroxbuster`, Kiterunner). See the individual INFO scenarios and the [API Reconnaissance](../12-API_Testing/01-API_Reconnaissance.md) chapter for concrete examples.
+
+Always stay within the defined scope of the engagement.

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Reconnaissance_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Reconnaissance_for_Information_Leakage.md
@@ -81,6 +81,78 @@ Additional services for viewing cached or archived web pages include:
 - [archive.ph](https://archive.ph) (also known as archive.md) - On-demand archiving service that creates permanent snapshots
 - [CachedView](https://cachedview.com/) - Aggregates cached pages from multiple sources including Google Cache historical data, Wayback Machine, and others
 
+### Automated Archive URL Collection
+
+In addition to browsing the Wayback Machine calendar view, testers commonly automate the collection of historical URLs. These URLs frequently reveal forgotten endpoints, old API paths, backup files, and parameters that are no longer linked from the live application.
+
+- [gau](https://github.com/lc/gau) - Aggregates known URLs from AlienVault OTX, the Wayback Machine, and Common Crawl.
+- [waybackurls](https://github.com/tomnomnom/waybackurls) - Fetches URLs known to the Wayback Machine for a domain.
+- [waymore](https://github.com/xnl-h4ck3r/waymore) - Expands coverage across Wayback Machine, Common Crawl, AlienVault OTX, URLScan, and VirusTotal, and can also retrieve historical responses.
+
+Example workflow:
+
+```bash
+gau example.com --verbose --threads 8 | tee gau.txt
+```
+
+```text
+WARN[0000] error reading config: Config file /Users/whoever/.gau.toml not found, using default config
+INFO[0000] fetching example.com                          page=0 provider=wayback
+INFO[0000] fetching example.com                          page=0 provider=urlscan
+INFO[0000] fetching example.com                          page=0 provider=otx
+https://code.example.com/team/content.git@
+https://code.example.com/team/content.git
+https://example.com/smoke-slug
+https://example.com/pay
+https://app.example.com
+...
+```
+
+```bash
+waybackurls example.com | tee wayback.txt
+```
+
+```text
+https://example.com/
+https://example.com/robots.txt
+https://example.com/sitemap.xml
+https://example.com/old-api/v1/users
+https://backup.example.com/db.sql
+...
+```
+
+```bash
+waymore -i example.com -mode U -o waymore.txt
+```
+
+```text
+waymore v0.10 by Xnl-h4ck3r
+[+] Getting URLs from Wayback Machine, Common Crawl, AlienVault OTX, URLScan and VirusTotal
+https://example.com/
+https://example.com/careers
+https://staging.example.com/login
+https://example.com/backup.zip
+...
+```
+
+[unfurl](https://github.com/tomnomnom/unfurl) is useful for extracting components (keys, paths, domains, etc.) from large URL lists produced by the tools above.
+
+```bash
+# Expand and clean URLs (optional)
+cat gau.txt wayback.txt waymore.txt | unfurl --unique keys | sort -u > urls.txt
+```
+
+```text
+db.sql
+login
+old-api
+robots.txt
+sitemap.xml
+...
+```
+
+The resulting URL list can be filtered for interesting extensions, parameters, or status codes and later fed into content-discovery or vulnerability scanners. Always validate that discovered hosts and paths remain in scope.
+
 ### Google Hacking or Dorking
 
 Searching with operators can be a very effective discovery technique when combined with the creativity of the tester. Operators can be chained to effectively discover specific kinds of sensitive files and information. This technique, called [Google hacking](https://en.wikipedia.org/wiki/Google_hacking) or Dorking, is also possible using other search engines, as long as the search operators are supported.
@@ -105,6 +177,12 @@ Some categories of dorks available on this database include:
 Beyond individual search engines, testers can use dedicated OSINT frameworks to correlate and visualize relationships between discovered entities:
 
 [Maltego](https://maltego.com) is an industry-standard OSINT and link analysis platform that maps relationships between domains, IP addresses, email addresses, and organizations through automated data transforms. Testers use it to visualize an organization's attack surface by pivoting from a single entity to discover related infrastructure and associated data points. A free Community Edition is available for non-commercial use.
+
+Additional modern OSINT tools commonly used alongside search-engine reconnaissance include:
+
+- [theHarvester](https://github.com/laramies/theHarvester): Emails, subdomains and names Harvester - OSINT.
+- [Amass](https://github.com/owasp-amass/amass) (passive mode): In-depth attack surface mapping and asset discovery.
+- [subfinder](https://github.com/projectdiscovery/subfinder): Fast passive subdomain enumeration tool.
 
 ## Remediation
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/04-Attack_Surface_Identification.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/04-Attack_Surface_Identification.md
@@ -118,6 +118,14 @@ This confirms that in fact it is an HTTP server. Alternatively, testers could ha
 
 The same task may be performed by vulnerability scanners, but first check that the scanner of choice is able to identify HTTP[S] services running on non-standard ports. For example, Nessus is capable of identifying them on arbitrary ports (provided it is instructed to scan all the ports), and will provide, with respect to Nmap, a number of tests on known web server vulnerabilities, as well as on the TLS/SSL configuration of HTTPS services. As hinted before, Nessus is also able to spot popular applications or web interfaces which could otherwise go unnoticed (for example, a Tomcat administrative interface).
 
+A full 65535-port Nmap scan with service detection can be slow across many hosts. [naabu](https://github.com/projectdiscovery/naabu) is a fast port scanner that can be used to quickly identify open ports across a large host list, and can pipe its results straight into Nmap for service detection on just the open ports it found:
+
+```bash
+naabu -p - -rate 2000 -c 50 -retries 2 -warm-up-time 1 -silent -host 192.168.1.100 -nmap-cli 'nmap -sV -oX scan.xml'
+```
+
+This combination scans all ports with naabu first, then only runs the slower Nmap service-detection scan against the ports naabu found open, considerably reducing total scan time.
+
 ### Approaches to Address Issue 3 - Virtual Hosts
 
 There are a number of techniques which may be used to identify DNS names associated to a given IP address `x.y.z.t`.
@@ -140,6 +148,8 @@ Passive techniques do not directly interact with the target infrastructure and i
 
 Passive techniques are preferred during early reconnaissance phases to avoid detection.
 
+[Chaos](https://chaos.projectdiscovery.io/) and its [chaos-client](https://github.com/projectdiscovery/chaos-client) provide access to a curated dataset of subdomains that ProjectDiscovery has already crawled, primarily sourced from public bug bounty program scopes. It can be a useful, fast supplement to passive DNS enumeration for domains it has already indexed, but it requires an API key, only covers domains within its dataset, and should not be relied on as a substitute for active tools such as `subfinder` or `amass` against arbitrary engagement targets.
+
 #### Active DNS Enumeration
 
 Active techniques directly query the target's DNS infrastructure and may generate logs on the target systems. These include:
@@ -157,7 +167,38 @@ Common tools used for DNS enumeration include:
 - `dig`
 - `nslookup`
 
-Example using `dig`: `dig example.com ANY`
+Example using `dig`:
+
+```bash
+dig example.com ANY
+```
+
+```text
+; <<>> DiG 9.10.6 <<>> example.com ANY
+;; QUESTION SECTION:
+;example.com.                  IN      ANY
+
+;; ANSWER SECTION:
+example.com.            86400   IN      A       93.184.216.34
+example.com.            86400   IN      MX      10 mail.example.com.
+example.com.            86400   IN      NS      ns1.secure.net.
+example.com.            86400   IN      NS      ns2.secure.net.
+example.com.            86400   IN      TXT     "v=spf1 -all"
+```
+
+Example using `subfinder`:
+
+```bash
+subfinder -d example.com -silent
+```
+
+```text
+www.example.com
+dev.example.com
+staging.example.com
+mail.example.com
+api.example.com
+```
 
 #### DNS Zone Transfers
 
@@ -205,6 +246,8 @@ Reverse-IP services are similar to DNS inverse queries, with the difference that
 - [DNSstuff](https://www.dnsstuff.com/) (multiple services available)
 - [Net Square](https://web.archive.org/web/20190515092354/https://www.net-square.com/mspawn.html) (multiple queries on domains and IP addresses, requires installation)
 
+Internet asset search engines such as [Shodan](https://www.shodan.io/), [Censys](https://censys.io), and [FOFA](https://fofa.info) index internet-connected hosts and services and can also be searched by IP, certificate, or banner content to reveal other hostnames and services hosted on the same address. FOFA in particular has extensive coverage of infrastructure in China and Asia-Pacific, which can complement the coverage of Shodan and Censys. For example, an IP-based FOFA search: `ip="192.168.1.100"`, or a search for a specific title or header: `title="Example App"`. As with the other reverse-IP services above, a free tier with limited queries is available, with paid plans for more comprehensive access.
+
 #### Googling
 
 Following information gathering from the previous techniques, testers can rely on search engines to possibly refine and increment their analysis. This may yield evidence of additional symbolic names belonging to the target, or applications accessible via non-obvious URLs.
@@ -249,18 +292,55 @@ One common approach to querying CT logs is to use publicly available search port
 
 For instance: `https://crt.sh/?q=%25.example.com`
 
+> Note: [crt.sh](https://crt.sh) has occasional periods of downtime or high latency. [Merklemap](https://www.merklemap.com/) and [SSLMate's Cert Spotter](https://sslmate.com/certspotter/) are alternative Certificate Transparency search services worth having as a fallback.
+
 ![CT Log Search Example](images/01-figure-4.1.4-ct-logs-example.png)  
 
 *Figure 4.1.4-1: Example of Certificate Transparency log search results.*
 
 The results may list subdomains such as `dev.example.com`, `staging.example.com`, or other hostnames that are not directly referenced from the primary site. Discovered hostnames should be validated through DNS resolution before further testing.
 
+### Example Modern Passive-to-Active Workflow
+
+A common lightweight pipeline used in contemporary assessments:
+
+```bash
+# Passive subdomain discovery
+subfinder -d example.com -silent | tee subs.txt
+amass enum -passive -d example.com -o amass.txt
+
+# Resolve and probe live hosts
+cat subs.txt amass.txt | sort -u | dnsx -silent | httpx -silent -title -tech-detect -status-code -o live.txt
+
+# Historical URLs (feed interesting hosts later)
+cat live.txt | unfurl domains | sort -u | gau --subs | tee archive-urls.txt
+
+# Screenshot live hosts for visual triage of a large host list
+gowitness scan file -f live.txt
+```
+
+With a large number of discovered hosts, screenshotting each one provides a quick way to visually triage results, for example spotting login pages, admin panels, default install pages, or error pages without visiting every host manually. [gowitness](https://github.com/sensepost/gowitness) is a current, actively maintained tool for this; `httpx` also supports a built-in `-screenshot` flag for the same purpose without adding another tool to the chain.
+
+Always respect scope, rate limits, and engagement rules of engagement. Validate ownership of newly discovered assets before deeper testing.
+
 ## Tools
 
 - DNS lookup tools such as `nslookup`, `dig`, and `host`
-- Subdomain enumeration tools such as `amass`, `subfinder`, `dnsrecon`, and `fierce`
+- Subdomain enumeration and attack-surface mapping tools:
+    - [Amass](https://github.com/owasp-amass/amass) (OWASP project – passive + active, graph output)
+    - [subfinder](https://github.com/projectdiscovery/subfinder)
+    - [Chaos](https://chaos.projectdiscovery.io/) / [chaos-client](https://github.com/projectdiscovery/chaos-client) (curated subdomain dataset, API key required)
+    - [dnsx](https://github.com/projectdiscovery/dnsx)
+    - [httpx](https://github.com/projectdiscovery/httpx) (live host probing, tech detection, titles)
+    - [gowitness](https://github.com/sensepost/gowitness) (screenshotting for visual triage of live hosts)
+    - `dnsrecon`, `fierce`
 - Search engines (Google, Bing, and other major search engines)
 - Reverse IP lookup services
+- Internet asset search engines: [Shodan](https://www.shodan.io/), [Censys](https://censys.io), [FOFA](https://fofa.info)
+- Certificate Transparency search portals: [crt.sh](https://crt.sh), [Merklemap](https://www.merklemap.com/), [SSLMate's Cert Spotter](https://sslmate.com/certspotter/)
+- Archive / historical URL collectors: [gau](https://github.com/lc/gau), [waybackurls](https://github.com/tomnomnom/waybackurls), [waymore](https://github.com/xnl-h4ck3r/waymore)
 - [Nmap](https://nmap.org/)
+- [naabu](https://github.com/projectdiscovery/naabu) (fast port scanning, can pipe results into Nmap)
 - [Nessus Vulnerability Scanner](https://www.tenable.com/products/nessus)
 - [Nikto](https://github.com/sullo/nikto)
+- Content / virtual-host discovery: [ffuf](https://github.com/ffuf/ffuf), [feroxbuster](https://github.com/epi052/feroxbuster), [gobuster](https://github.com/OJ/gobuster)

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Web_Page_Content_for_Information_Leakage.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Web_Page_Content_for_Information_Leakage.md
@@ -105,7 +105,6 @@ When an API Key is found, testers can check if the API Key restrictions are set 
 For example, if testers find a Google Map API Key, they can check if this API Key is restricted by IP or restricted only per the Google Map APIs. If the Google API Key is restricted only per the Google Map APIs, attackers can still use that API Key to query unrestricted Google Map APIs and the application owner must pay for that.
 
 ```html
-
 <script type="application/json">
 ...
 {"GOOGLE_MAP_API_KEY":"AIzaSyDUEBnKgwiqMNpDplT6ozE4Z0XxuAbqDi4", "RECAPTCHA_KEY":"6LcPscEUiAAAAHOwwM3fGvIx9rsPYUq62uRhGjJ0"}
@@ -122,6 +121,21 @@ In some cases, testers may find sensitive routes from JavaScript code, such as l
 ...
 </script>
 ```
+
+#### JavaScript and Client-Side Source Analysis
+
+Modern single-page applications and heavy client-side code frequently embed API endpoints, feature flags, and occasionally secrets. After collecting JavaScript files (manually, via proxy, or with tools such as Uproot), testers can extract interesting data with:
+
+```bash
+# Example with jsluice
+jsluice urls bundle.js
+jsluice secrets bundle.js
+
+# Example with LinkFinder
+python linkfinder.py -i bundle.js -o cli
+```
+
+Cross-reference extracted endpoints and parameters with the results of archive URL collection (gau / waybackurls / waymore) and the techniques described in [Identify Application Entry Points](06-Identify_Application_Entry_Points.md), and the [API Reconnaissance](../12-API_Testing/01-API_Reconnaissance.md) chapter.
 
 ### Identifying Source Map Files
 
@@ -203,6 +217,13 @@ Check metadata fields such as:
 - [Zed Attack Proxy (ZAP)](https://www.zaproxy.org)
 - [Burp Suite](https://portswigger.net/burp)
 - [Waybackurls](https://github.com/tomnomnom/waybackurls)
+- [gau](https://github.com/lc/gau)
+- [waymore](https://github.com/xnl-h4ck3r/waymore)
+- JavaScript endpoint / secret extraction:
+    - [LinkFinder](https://github.com/GerbenJavado/LinkFinder)
+    - [xnLinkFinder](https://github.com/xnl-h4ck3r/xnLinkFinder)
+    - [jsluice](https://github.com/BishopFox/jsluice)
+    - [SecretFinder](https://github.com/m4ll0k/SecretFinder) (or similar regex-based tools)
 - [Google Maps API Scanner](https://github.com/ozguralp/gmapsapiscanner/)
 - [exiftool](https://exiftool.org/)
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points.md
@@ -109,7 +109,7 @@ You can also generate a JSON output file using the `-json` flag, which can be us
 
 The following are two examples on how to check for application entry points.
 
-#### Example 1
+#### GET Requests
 
 This example shows a GET request that would purchase an item from an online shopping application.
 
@@ -121,7 +121,7 @@ Cookie: SESSIONID=Z29vZCBqb2IgcGFkYXdhIG15IHVzZXJuYW1lIGlzIGZvbyBhbmQgcGFzc3dvc
 
 > All the parameters of the request such as CUSTOMERID, ITEM, PRICE, IP, and the Cookie, which could just be encoded parameters or parameters used for session state.
 
-#### Example 2
+#### POST Requests
 
 This example shows a POST request that would log you into an application.
 
@@ -146,6 +146,10 @@ Having a variety of injection locations provides the attacker with chaining poss
 - [Zed Attack Proxy (ZAP)](https://www.zaproxy.org/)
 - [Burp Suite](https://www.portswigger.net/burp/)
 - [Fiddler](https://www.telerik.com/fiddler)
+- Content and parameter discovery: [ffuf](https://github.com/ffuf/ffuf), [feroxbuster](https://github.com/epi052/feroxbuster), [Arjun](https://github.com/s0md3v/Arjun)
+- Crawlers: [katana](https://github.com/projectdiscovery/katana), [hakrawler](https://github.com/hakluke/hakrawler)
+- Historical URL sources: [gau](https://github.com/lc/gau), [waybackurls](https://github.com/tomnomnom/waybackurls), [waymore](https://github.com/xnl-h4ck3r/waymore)
+- See also the tooling listed in [API Reconnaissance](../12-API_Testing/01-API_Reconnaissance.md) (Kiterunner, LinkFinder, jsluice, xnLinkFinder, Param Miner, etc.)
 
 ## References
 

--- a/document/4-Web_Application_Security_Testing/01-Information_Gathering/README.md
+++ b/document/4-Web_Application_Security_Testing/01-Information_Gathering/README.md
@@ -1,5 +1,7 @@
 # 4.1 Information Gathering
 
+4.1.0 [Information Gathering Overview](00-Information_Gathering_Overview.md)
+
 4.1.1 [Conduct Search Engine Reconnaissance for Information Leakage](01-Conduct_Search_Engine_Reconnaissance_for_Information_Leakage.md)
 
 4.1.2 [Fingerprint Web Server](02-Fingerprint_Web_Server.md)

--- a/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management/06-HTTP_Methods.md
+++ b/document/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management/06-HTTP_Methods.md
@@ -21,6 +21,7 @@ HTTP offers a number of methods (or verbs) that can be used to perform actions o
 | [`OPTIONS`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7) | List supported HTTP methods. | Perform a [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) request. |
 | [`TRACE`](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.8) | Echo the HTTP request for debug purposes. | |
 | [`PATCH`](https://datatracker.ietf.org/doc/html/rfc5789#section-2) |  | Modify an object. |
+| [`QUERY`](https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.7) | Safe retrieval of data with a request body. | Query objects or resources with complex parameters. |
 
 ## Test Objectives
 
@@ -173,6 +174,32 @@ Host: example.org
 
 As with the `PUT` method, this functionality may have access control weaknesses or other vulnerabilities. Additionally, applications may not perform the same level of input validation when modifying an object as they do when creating one. This could potentially allow malicious values to be injected (such as in a stored cross-site scripting attack), or could allow broken or invalid objects that may result in business logic related issues.
 
+### QUERY
+
+The `QUERY` method is a relatively newer HTTP method defined in [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110), designed for safe retrieval operations that require a request body. Like `POST`, it accepts structured data in the request body; unlike `POST`, it is safe and idempotent, meaning it does not modify server state and can be cached. This makes it semantically similar to `GET` but allows the expressiveness of complex filter parameters etc that would be unwieldy in a URL.
+
+For example, the `QUERY` method could be used to submit a complex search query with multiple filter criteria:
+
+```http
+QUERY /api/users/search HTTP/1.1
+Host: example.org
+Content-Type: application/json
+
+{
+    "filters": {
+        "role": "admin",
+        "status": "active",
+        "lastLogin": {"after": "2024-01-01"}
+    }
+}
+```
+
+The `QUERY` method is designed to be cacheable and safe (read-only), making it distinct from `POST`. It should not be used for operations that modify state on the server. Testers should verify that:
+
+- The server correctly treats `QUERY` as a safe operation and does not modify server state.
+- Access control is properly enforced for `QUERY` requests.
+- The method is not used as a workaround to bypass security controls that restrict other methods.
+
 ### Access Control Bypass
 
 If a page on the application redirects users to a login page with a 302 code when they attempt to access it directly, it may be possible to bypass this by making a request with a different HTTP method, such as `HEAD`, `POST` or even a made up method such as `FOO`. If the web application responds with a `HTTP/1.1 200 OK` rather than the expected `HTTP/1.1 302 Found`, it may then be possible to bypass the authentication or authorization. The example below shows how a `HEAD` request may result in a page setting administrative cookies, rather than redirecting the user to a login page:
@@ -255,6 +282,7 @@ HTTP/1.1 200 OK
 
 - [RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1)](https://datatracker.ietf.org/doc/html/rfc7231)
 - [RFC 5789 - PATCH Method for HTTP](https://datatracker.ietf.org/doc/html/rfc5789)
+- [RFC 9110 - HTTP Semantics](https://datatracker.ietf.org/doc/html/rfc9110)
 - [HTACCESS: BILBAO Method Exposed](https://web.archive.org/web/20160616172703/https://www.kernelpanik.org/docs/kernelpanik/bme.eng.pdf)
 - [Fortify - Misused HTTP Method Override](https://vulncat.fortify.com/en/detail?id=desc.dynamic.xtended_preview.often_misused_http_method_override)
 - [Mozilla Developer Network - Safe HTTP Methods](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP)

--- a/document/4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance.md
+++ b/document/4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance.md
@@ -164,6 +164,18 @@ Regular expression is more straightforward by searching JS or HTML content for k
 3. [xnLinkFinder](https://github.com/xnl-h4ck3r/xnLinkFinder). A python tool used to discover endpoints, potential parameters, and a target specific wordlist for a given target.
 4. [GAP](https://github.com/xnl-h4ck3r/GAP-Burp-Extension). Burp Extension to find potential endpoints, parameters, and generate a custom target wordlist.
 
+### Port Scanning
+
+API servers are often deployed on non-standard ports, or alongside other exposed services (internal admin panels, gRPC or WebSocket listeners, debug/metrics endpoints) that a documentation-only review would miss. [naabu](https://github.com/projectdiscovery/naabu) is a fast port scanner that can quickly enumerate open ports across the identified hosts, and can pipe its results directly into Nmap for service detection on just the ports found open:
+
+```bash
+naabu -p - -rate 2000 -c 50 -retries 2 -warm-up-time 1 -silent -host api.example.com -nmap-cli 'nmap -sV -oX scan.xml'
+```
+
+Running this scan first, and Nmap's slower full service-detection scan only against the ports naabu reports as open, considerably reduces total scan time compared to a direct full-range Nmap scan. See [Improving Port Scans Against API Servers](https://danaepp.com/improving-port-scans-against-api-servers) for further tuning guidance specific to API targets, including why CONNECT scans can outperform SYN scans under high concurrency, and how to avoid missing services due to rate-limiting or firewalling.
+
+Also see [Attack Surface Identification](../01-Information_Gathering/04-Attack_Surface_Identification.md) for further discussion of non-standard port discovery.
+
 ### Active Fuzzing
 
 Active Fuzzing involves using tools with wordlists and filtering requests results to bruteforce endpoint discovery.


### PR DESCRIPTION
- Document QUERY HTTP method (RFC 9110) with safe retrieval semantics
- Add Information Gathering Overview (4.1.0) covering discovery approach
- Expand INFO scenarios with tool examples: gau, waybackurls, waymore, subfinder, jsluice, LinkFinder
- Add dig/subfinder/workflow examples to Attack Surface Identification
- Enhance entry-point discovery tools; improve semantic headings (GET/POST)
- Cross-reference API Reconnaissance chapter throughout
- Add gowitness for screenshot-based visual triage of live hosts
- Add naabu+Nmap pipeline for faster full-port scanning, cross-linked into API Reconnaissance for port scanning API servers
- Note Chaos/chaos-client as a curated passive subdomain data source (API key required, bug-bounty-scope dataset, not a substitute for active enumeration tools)
- Add FOFA alongside Shodan/Censys as an internet asset search engine  for reverse-IP style lookups

Fixes #1058 
